### PR TITLE
Bug fix: fix peerDependencies ranges.

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,3 @@
-save-prefix ""
+# Ensure calling `yarn add` installs exact version of package
+# https://yarnpkg.com/en/docs/cli/add#toc-yarn-add-exact-e
+--add.exact true

--- a/dist/package.json
+++ b/dist/package.json
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/Simspace/monorail#readme",
   "dependencies": {},
   "peerDependencies": {
-    "fp-ts": "~1.13.0",
-    "react": "~16.6.0",
-    "react-dom": "~16.6.0",
-    "react-router": "~3.2.0",
-    "styled-components": "~4.0.0"
+    "fp-ts": "^1.13.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
+    "react-router": "^3.2.0",
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",

--- a/package.json
+++ b/package.json
@@ -31,11 +31,11 @@
   "homepage": "https://github.com/Simspace/monorail#readme",
   "dependencies": {},
   "peerDependencies": {
-    "fp-ts": "~1.13.0",
-    "react": "~16.6.0",
-    "react-dom": "~16.6.0",
-    "react-router": "~3.2.0",
-    "styled-components": "~4.0.0"
+    "fp-ts": "^1.13.0",
+    "react": "^16.6.0",
+    "react-dom": "^16.6.0",
+    "react-router": "^3.2.0",
+    "styled-components": "^4.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.2",


### PR DESCRIPTION
# Overview

`peerDependencies` ranges are too specific as `monorail` works for more than just the exact version