### PR TITLE
Update Monorail Week 23 Release

### DIFF
--- a/dist/actionsButtons/ActionsButtons.d.ts
+++ b/dist/actionsButtons/ActionsButtons.d.ts
@@ -1,0 +1,14 @@
+import { FC, ReactNode } from 'react';
+import { ActionsMenuProps } from '@monorail/actionsMenu/ActionsMenu';
+import { ButtonDisplay, ButtonSize } from '@monorail/buttons/buttonTypes';
+import { PopOverToggleProps } from '@monorail/popOver/PopOver';
+export declare type ActionsButtonsProps = {
+    display?: ButtonDisplay;
+    featuredActions?: Array<Omit<ActionsMenuProps['menuItems'][0], 'featuredAction'>>;
+    standardActions?: Array<Omit<ActionsMenuProps['menuItems'][0], 'featuredAction'>>;
+    size?: ButtonSize;
+    iconOnly?: boolean;
+    document?: Document;
+    toggle?: (props: PopOverToggleProps) => ReactNode;
+};
+export declare const ActionsButtons: FC<ActionsButtonsProps>;

--- a/dist/actionsButtons/ActionsButtons.js
+++ b/dist/actionsButtons/ActionsButtons.js
@@ -1,0 +1,63 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.ActionsButtons = void 0;
+
+var _styledComponents = _interopRequireWildcard(require("styled-components"));
+
+var _react = _interopRequireDefault(require("react"));
+
+var _ActionsMenu = require("../actionsMenu/ActionsMenu");
+
+var _Button = require("../buttons/Button");
+
+var _IconButton = require("../buttons/IconButton");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+const combineActions = (standardActions = [], featuredActions = []) => featuredActions.map(action => ({ ...action,
+  featuredAction: true,
+
+  /**
+   * Remapping onClick to be able to close the action menu.
+   * This wouldn't be necessary if the interfaces were the same
+   */
+  onClick: parentClick => {
+    action.onClick(() => {});
+    parentClick();
+  }
+})).concat(standardActions);
+
+const ActionsButtons = ({
+  display,
+  document,
+  featuredActions,
+  iconOnly,
+  size,
+  standardActions
+}) => _react.default.createElement(_react.default.Fragment, null, featuredActions && featuredActions.map(action => iconOnly ? _react.default.createElement(_IconButton.IconButton, {
+  key: `${action.label}-${action.iconName}`,
+  icon: action.iconName,
+  title: action.label,
+  size: size,
+  display: display,
+  onClick: () => action.onClick(() => {})
+}) : _react.default.createElement(_Button.Button, {
+  key: `${action.label}-${action.iconName}`,
+  size: size,
+  display: display,
+  iconLeft: action.iconName // hacky because of the onClick type of ActionMenu's menu items
+  ,
+  onClick: () => action.onClick(() => {})
+}, action.label)), standardActions && _react.default.createElement(_StyledActionsMenu, {
+  document: document,
+  menuItems: combineActions(standardActions, featuredActions)
+}));
+
+exports.ActionsButtons = ActionsButtons;
+
+var _StyledActionsMenu = (0, _styledComponents.default)(_ActionsMenu.ActionsMenu)`margin-left:8px;`;

--- a/dist/actionsMenu/ActionsMenu.d.ts
+++ b/dist/actionsMenu/ActionsMenu.d.ts
@@ -5,6 +5,12 @@ export declare type ActionsMenuProps = {
     menuItems: Array<{
         label: string;
         iconName?: string;
+        /**
+         * TODO: get rid of the need to have to pass a callback to close the popover.
+         * This onClick should match the signature of all other react onClick.
+         * If we weren't depending on asynchronous behavior in components that are consuming
+         * ActionsMenu we would just be able to stop propagation on the SyntheticEvent
+         */
         onClick: (onClickParent: () => void) => void;
         featuredAction?: boolean;
         children?: ReactNode;

--- a/dist/actionsMenu/ActionsMenu.js
+++ b/dist/actionsMenu/ActionsMenu.js
@@ -5,11 +5,15 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.ActionsMenu = void 0;
 
+var _styledComponents = _interopRequireWildcard(require("styled-components"));
+
 var _react = _interopRequireDefault(require("react"));
 
 var _buttonTypes = require("../buttons/buttonTypes");
 
 var _IconButton = require("../buttons/IconButton");
+
+var _Divider = require("../divider/Divider");
 
 var _size = require("../helpers/size");
 
@@ -21,6 +25,8 @@ var _PopOver = require("../popOver/PopOver");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
 function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 /*
@@ -31,30 +37,41 @@ const ActionsMenu = ({
   menuItems,
   toggle,
   ...domProps
-}) => _react.default.createElement(_react.default.Fragment, null, menuItems.length > 0 && _react.default.createElement(_PopOver.PopOver, {
-  document: document,
-  popOver: ({
-    onClick,
-    ...otherProps
-  }) => _react.default.createElement(_Menu.Menu, _extends({
-    onClick: onClick
-  }, otherProps), menuItems.map((menuItem, idx) => _react.default.createElement(_List.SimpleListItem, {
-    key: idx + menuItem.label,
-    size: _size.Sizes.DP32,
-    leftIcon: menuItem.iconName,
-    primaryText: menuItem.label,
-    onClick: e => menuItem.onClick(() => onClick(e))
-  }, menuItem.children))),
-  toggle: props => toggle({ ...props,
-    ...domProps
-  })
-}));
+}) => {
+  const featuredItems = menuItems.filter(x => x.featuredAction);
+  const standardItems = menuItems.filter(x => !x.featuredAction);
+  return _react.default.createElement(_react.default.Fragment, null, menuItems.length > 0 && _react.default.createElement(_PopOver.PopOver, {
+    document: document,
+    popOver: ({
+      onClick,
+      ...otherProps
+    }) => _react.default.createElement(_Menu.Menu, _extends({
+      onClick: onClick
+    }, otherProps), featuredItems.map((menuItem, idx) => _react.default.createElement(_List.SimpleListItem, {
+      key: idx + menuItem.label,
+      size: _size.Sizes.DP32,
+      leftIcon: menuItem.iconName,
+      primaryText: menuItem.label,
+      onClick: e => menuItem.onClick(() => onClick(e))
+    }, menuItem.children)), _react.default.createElement(_StyledDivider, null), standardItems.map((menuItem, idx) => _react.default.createElement(_List.SimpleListItem, {
+      key: idx + menuItem.label,
+      size: _size.Sizes.DP32,
+      leftIcon: menuItem.iconName,
+      primaryText: menuItem.label,
+      onClick: e => menuItem.onClick(() => onClick(e))
+    }, menuItem.children))),
+    toggle: props => toggle({ ...props,
+      ...domProps
+    })
+  }));
+};
 
 exports.ActionsMenu = ActionsMenu;
 ActionsMenu.defaultProps = {
   toggle: props => _react.default.createElement(_IconButton.IconButton, _extends({
     icon: "more_vert",
-    display: _buttonTypes.ButtonDisplay.Chromeless,
-    shape: _buttonTypes.IconButtonShape.Default
+    display: _buttonTypes.ButtonDisplay.Chromeless
   }, props))
 };
+
+var _StyledDivider = (0, _styledComponents.default)(_Divider.Divider)`margin:4px 0 3px;`;

--- a/dist/appIcon/AppIcon.js
+++ b/dist/appIcon/AppIcon.js
@@ -26,7 +26,7 @@ const AppIcon =
   cssOverrides,
   ...otherProps
 }) => _react.default.createElement("div", otherProps, _react.default.createElement(_Icon.Icon, {
-  icon: appName
+  icon: `${appName}-app`
 })))(({
   cssOverrides
 }) => (0, _styledComponents.css)(["", ";", ";box-sizing:border-box;height:16px;width:16px;", "{fill:", ";height:100%;margin:auto;width:100%;}", ";"], (0, _exports.flexFlow)('row'), (0, _exports.borderRadius)(), _Icon.Icon, (0, _exports.getColor)(_exports.Colors.White), cssOverrides)); // tslint:enable

--- a/dist/buttons/Button.d.ts
+++ b/dist/buttons/Button.d.ts
@@ -41,6 +41,7 @@ declare type FunctionalProps = {
     onMouseUp?: OnClick;
     pressed: boolean;
     size: ButtonSize;
+    title?: string;
     type: 'button' | 'reset' | 'submit';
 };
 declare type DefaultProps = IconProps & FunctionalProps;

--- a/dist/buttons/LoadingButton.d.ts
+++ b/dist/buttons/LoadingButton.d.ts
@@ -26,6 +26,7 @@ export declare class LoadingButton extends Component<Props, State> {
         onMouseUp?: import("./Button").OnClick | undefined;
         pressed: boolean;
         size: import("./buttonTypes").ButtonSize;
+        title?: string | undefined;
         type: "button" | "reset" | "submit";
     };
     state: State;

--- a/dist/filters/Filter.d.ts
+++ b/dist/filters/Filter.d.ts
@@ -1,5 +1,8 @@
 import { Component, ReactNode } from 'react';
 import { SimpleInterpolation } from 'styled-components';
+export declare const CCFilter: import("styled-components").StyledComponent<"div", any, CCFilterProps, never>;
+export declare const FilterText: import("styled-components").StyledComponent<"span", any, {}, never>;
+export declare const FilterIcon: import("styled-components").StyledComponent<({ cssOverrides: _cssOverrides, icon, ...otherProps }: import("../icon/Icon").IconProps) => JSX.Element, any, import("../icon/Icon").IconProps, never>;
 declare type CCFilterProps = {
     cssOverrides?: SimpleInterpolation;
     isActive: boolean;

--- a/dist/filters/Filter.js
+++ b/dist/filters/Filter.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Filter = void 0;
+exports.Filter = exports.FilterIcon = exports.FilterText = exports.CCFilter = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -35,6 +35,8 @@ _styledComponents.default.div.withConfig({
   cssOverrides
 }) => (0, _styledComponents.css)(["", ";", ";", ";", ";align-items:center;cursor:pointer;height:24px;padding:0 4px 0 8px;user-select:none;flex-shrink:0;", ";"], isActive ? (0, _exports.basePrimaryStyles)(_theme.ThemeColors.BrandSecondary) : (0, _styledComponents.css)(["", ";color:", ";"], (0, _exports.baseSecondaryStyles)(_theme.ThemeColors.BrandSecondary), (0, _exports.getColor)(_exports.Colors.Black74)), (0, _exports.borderRadius)(), _exports.buttonTransition, (0, _exports.flexFlow)('row'), cssOverrides));
 
+exports.CCFilter = CCFilter;
+
 const FilterText =
 /*#__PURE__*/
 _styledComponents.default.span.withConfig({
@@ -42,12 +44,14 @@ _styledComponents.default.span.withConfig({
   componentId: "sc-131i0x6-1"
 })(["", ";color:currentColor;text-transform:uppercase;white-space:nowrap;"], (0, _exports.typography)(700, _exports.FontSizes.Title5));
 
+exports.FilterText = FilterText;
 const FilterIcon =
 /*#__PURE__*/
 (0, _styledComponents.default)(_Icon.Icon).withConfig({
   displayName: "Filter__FilterIcon",
   componentId: "sc-131i0x6-2"
 })(["color:currentColor;"]);
+exports.FilterIcon = FilterIcon;
 
 class Filter extends _react.Component {
   render() {

--- a/dist/helpers/color.d.ts
+++ b/dist/helpers/color.d.ts
@@ -1,5 +1,7 @@
 export declare enum Colors {
+    Black12 = "black12",
     Black24 = "black24",
+    Black38 = "black38",
     Black54 = "black54",
     Black62 = "black62",
     Black74 = "black74",

--- a/dist/helpers/color.js
+++ b/dist/helpers/color.js
@@ -8,7 +8,9 @@ let Colors;
 exports.Colors = Colors;
 
 (function (Colors) {
+  Colors["Black12"] = "black12";
   Colors["Black24"] = "black24";
+  Colors["Black38"] = "black38";
   Colors["Black54"] = "black54";
   Colors["Black62"] = "black62";
   Colors["Black74"] = "black74";
@@ -67,11 +69,23 @@ const colorHSLAMap = ({
 }) => {
   const baseColors = {
     // Base Colors
+    [Colors.Black12]: {
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 0.12 * alpha
+    },
     [Colors.Black24]: {
       h: 0,
       s: 0,
       l: 0,
       a: 0.24 * alpha
+    },
+    [Colors.Black38]: {
+      h: 0,
+      s: 0,
+      l: 0,
+      a: 0.38 * alpha
     },
     [Colors.Black54]: {
       h: 0,

--- a/dist/hyperLink/BaseLink.d.ts
+++ b/dist/hyperLink/BaseLink.d.ts
@@ -1,0 +1,5 @@
+import { FC } from 'react';
+import { LinkProps } from 'react-router';
+export declare const BaseLink: FC<LinkProps & {
+    className?: string;
+}>;

--- a/dist/hyperLink/BaseLink.js
+++ b/dist/hyperLink/BaseLink.js
@@ -1,0 +1,32 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.BaseLink = void 0;
+
+var _react = _interopRequireDefault(require("react"));
+
+var _reactRouter = require("react-router");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// BaseLink does prop stripping for styled-components so that we don't have to strip props for every styled-component that uses a link.
+const BaseLink = ({
+  onlyActiveOnIndex,
+  to,
+  activeClassName,
+  activeStyle,
+  className,
+  children,
+  onClick
+}) => _react.default.createElement(_reactRouter.Link, {
+  onlyActiveOnIndex: onlyActiveOnIndex,
+  to: to,
+  activeClassName: activeClassName,
+  activeStyle: activeStyle,
+  className: className,
+  onClick: onClick
+}, children);
+
+exports.BaseLink = BaseLink;

--- a/dist/icon/Icon.js
+++ b/dist/icon/Icon.js
@@ -172,7 +172,7 @@ const Icon =
   icon,
   ...otherProps
 }) => {
-  const CustomIcon = customIcons[icon] || (0, _exports.isAppName)(icon) && customIcons[`${(0, _exports.convertAppNameToString)(icon)}-app`];
+  const CustomIcon = customIcons[icon];
 
   if (CustomIcon) {
     return _react.default.createElement(CustomIcon, otherProps);

--- a/dist/inputs/Choice.d.ts
+++ b/dist/inputs/Choice.d.ts
@@ -1,9 +1,12 @@
-import React, { Component, ReactNode } from 'react';
+import { ChangeEvent, CSSProperties, ReactNode } from 'react';
 import { SimpleInterpolation } from 'styled-components';
+import { FCwDP } from '@monorail/sharedHelpers/react';
 declare type AnsweredProps = {
     answered?: boolean;
-    htmlFor?: string;
+    centeredInput?: boolean;
+    dense?: boolean;
     disabled?: boolean;
+    indeterminate?: boolean;
 };
 declare type BBGradeIconProps = {
     correct?: boolean;
@@ -12,11 +15,10 @@ declare type BBGradeIconProps = {
 declare type BBChoiceInputProps = AnsweredProps & {
     checked?: boolean;
     defaultChecked?: boolean;
-    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 declare type CCChoiceProps = AnsweredProps & BBGradeIconProps & {
     cssOverrides?: SimpleInterpolation;
-    disabled?: boolean;
     readOnly?: boolean;
     value?: string | number | Array<string>;
     required?: boolean;
@@ -24,11 +26,26 @@ declare type CCChoiceProps = AnsweredProps & BBGradeIconProps & {
 };
 export declare type ChoiceProps = BBGradeIconProps & CCChoiceProps & BBChoiceInputProps & {
     key?: string | number;
-    type: 'radio' | 'checkbox';
+    type?: 'radio' | 'checkbox';
     children?: ReactNode;
+    style?: CSSProperties;
 };
-export declare class Choice extends Component<ChoiceProps> {
-    renderFakeInputIcons: () => JSX.Element[];
-    render(): JSX.Element;
-}
+declare type DefaultProps = {
+    answered: boolean;
+    disabled: boolean;
+    indeterminate: boolean;
+    correct: boolean;
+    incorrect: boolean;
+    checked: boolean;
+    defaultChecked: boolean;
+    cssOverrides: SimpleInterpolation;
+    readOnly: boolean;
+    value: string | number | Array<string>;
+    required: boolean;
+    name: string;
+    key: string | number;
+    type: 'radio' | 'checkbox';
+    children: ReactNode;
+};
+export declare const Choice: FCwDP<ChoiceProps, DefaultProps>;
 export {};

--- a/dist/inputs/Choice.js
+++ b/dist/inputs/Choice.js
@@ -5,7 +5,7 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.Choice = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
+var _react = _interopRequireDefault(require("react"));
 
 var _styledComponents = _interopRequireWildcard(require("styled-components"));
 
@@ -14,6 +14,10 @@ var _exports = require("../helpers/exports");
 var _Icon = require("../icon/Icon");
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = Object.defineProperty && Object.getOwnPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : {}; if (desc.get || desc.set) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } } newObj.default = obj; return newObj; } }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _extends() { _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; }; return _extends.apply(this, arguments); }
 
 /*
  * Styles
@@ -41,13 +45,16 @@ _styledComponents.default.label.withConfig({
   displayName: "Choice__CCChoice",
   componentId: "sc-16u3c70-2"
 })(({
-  disabled,
+  dense,
   readOnly,
   incorrect,
   correct,
-  cssOverrides,
-  answered
-}) => (0, _styledComponents.css)(["", ";", ";", ";", ";align-items:center;box-sizing:border-box;cursor:pointer;display:flex;flex-direction:row;min-height:24px;padding:4px 4px 4px 32px;position:relative;user-select:none;width:100%;", ";.ChoiceButtonChecked{color:", ";transform:translateX(", "px);}.ChoiceButtonUnchecked{color:", ";transform:translateX(", "px);}.RealInput:checked ~ .ChoiceButtonChecked{", ";}.RealInput:checked ~ .ChoiceButtonUnchecked{", ";}.RealInput:not(:checked) ~ .ChoiceButtonChecked{", ";}.RealInput:not(:checked) ~ .ChoiceButtonUnchecked{", ";}.IncorrectIcon{color:", ";", ";}.CorrectIcon{color:", ";", ";}", "{left:8px;position:absolute;font-size:16px;transition:all ease 150ms;}", ";"], (readOnly || incorrect || correct) && (0, _styledComponents.css)(["cursor:default;pointer-events:none;"]), (0, _exports.baseChromelessStyles)(), (0, _exports.flexFlow)('row'), (0, _exports.borderRadius)(), _exports.buttonTransition, (0, _exports.getColor)(_exports.Colors.BrandLightBlue), answered ? 24 : 0, (0, _exports.getColor)(_exports.Colors.Black54), answered ? 24 : 0, disabled && _exports.baseDisabledStyles, (0, _exports.visible)(false), (0, _exports.visible)(false), disabled && _exports.baseDisabledStyles, (0, _exports.getColor)(_exports.Colors.Red), (0, _exports.visible)(incorrect), (0, _exports.getColor)(_exports.Colors.Green), (0, _exports.visible)(correct), _Icon.Icon, cssOverrides));
+  cssOverrides
+}) => (0, _styledComponents.css)(["", ";", ";", ";", ";align-items:center;box-sizing:border-box;cursor:pointer;display:flex;flex-direction:row;min-height:24px;padding:", ";position:relative;user-select:none;width:100%;", ";", ";"], (readOnly || incorrect || correct) && (0, _styledComponents.css)(["cursor:default;pointer-events:none;"]), (0, _exports.baseChromelessStyles)(), (0, _exports.flexFlow)('row'), (0, _exports.borderRadius)(), dense ? '4px 4px 4px 24px' : '8px 8px 8px 32px', _exports.buttonTransition, cssOverrides));
+
+const baseIconStyles = (answered, dense) => (0, _styledComponents.css)(["font-size:16px;left:", ";position:absolute;top:", ";transition:all ease 150ms;transform:translateX(", "px);"], dense ? '4px' : '8px', dense ? '4px' : '8px', answered ? 24 : 0);
+
+const centeredIconStyles = (answered, dense) => (0, _styledComponents.css)(["align-items:center;font-size:16px;position:absolute;left:", ";transition:all ease 150ms;transform:translateX(", "px);"], dense ? '4px' : '8px', answered ? 24 : 0);
 /*
  * Types
  */
@@ -56,87 +63,216 @@ _styledComponents.default.label.withConfig({
 /*
  * Component
  */
-class Choice extends _react.Component {
-  constructor(...args) {
-    super(...args);
+const UncheckedRadioIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  checked,
+  answered,
+  dense,
+  centeredInput,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "radio_button_unchecked"
+}, otherProps)))(({
+  checked,
+  answered,
+  dense,
+  centeredInput
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(!checked), centeredInput ? centeredIconStyles(answered, dense) : baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.Black54)));
+const CheckedRadioIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  checked,
+  answered,
+  dense,
+  centeredInput,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "radio_button_checked"
+}, otherProps)))(({
+  checked,
+  answered,
+  dense,
+  centeredInput
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(checked), centeredInput ? centeredIconStyles(answered, dense) : baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.BrandLightBlue)));
+const UncheckedCheckboxIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  checked,
+  answered,
+  dense,
+  indeterminate,
+  centeredInput,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "check_box_outline_blank"
+}, otherProps)))(({
+  checked,
+  answered,
+  dense,
+  indeterminate,
+  centeredInput
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(!checked && !indeterminate), centeredInput ? centeredIconStyles(answered, dense) : baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.Black54)));
+const CheckedCheckboxIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  checked,
+  answered,
+  dense,
+  centeredInput,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "check_box"
+}, otherProps)))(({
+  checked,
+  answered,
+  dense,
+  centeredInput
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(checked), centeredInput ? centeredIconStyles(answered, dense) : baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.BrandLightBlue)));
+const IndeterminateIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  indeterminate,
+  answered,
+  dense,
+  centeredInput,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "indeterminate_check_box"
+}, otherProps)))(({
+  indeterminate,
+  answered,
+  dense,
+  centeredInput
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(indeterminate), centeredInput ? centeredIconStyles(answered, dense) : baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.BrandLightBlue)));
+const IncorrectIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  incorrect,
+  answered,
+  dense,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "cancel"
+}, otherProps)))(({
+  incorrect,
+  dense,
+  answered
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(incorrect), baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.Red)));
+const CorrectIcon =
+/*#__PURE__*/
+(0, _styledComponents.default)(({
+  correct,
+  answered,
+  dense,
+  ...otherProps
+}) => _react.default.createElement(_Icon.Icon, _extends({
+  icon: "check_circle"
+}, otherProps)))(({
+  correct,
+  dense,
+  answered
+}) => (0, _styledComponents.css)(["", ";", ";color:", ";"], (0, _exports.visible)(correct), baseIconStyles(answered, dense), (0, _exports.getColor)(_exports.Colors.Green)));
 
-    this.renderFakeInputIcons = () => {
-      const {
-        type
-      } = this.props;
+const renderFakeInputIcons = (type, centeredInput, checked, answered, dense, indeterminate) => {
+  switch (type) {
+    default:
+    case 'radio':
+      return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement(UncheckedRadioIcon, {
+        centeredInput: centeredInput,
+        checked: checked,
+        answered: answered,
+        dense: dense
+      }), _react.default.createElement(CheckedRadioIcon, {
+        centeredInput: centeredInput,
+        checked: checked,
+        answered: answered,
+        dense: dense
+      }));
 
-      switch (type) {
-        default:
-        case 'radio':
-          return [_react.default.createElement(_Icon.Icon, {
-            key: "radioNotChecked",
-            className: "ChoiceButtonUnchecked",
-            icon: "radio_button_unchecked"
-          }), _react.default.createElement(_Icon.Icon, {
-            key: "radioChecked",
-            className: "ChoiceButtonChecked",
-            icon: "radio_button_checked"
-          })];
-
-        case 'checkbox':
-          return [_react.default.createElement(_Icon.Icon, {
-            key: "radioNotChecked",
-            className: "ChoiceButtonUnchecked",
-            icon: "check_box_outline_blank"
-          }), _react.default.createElement(_Icon.Icon, {
-            key: "radioChecked",
-            className: "ChoiceButtonChecked",
-            icon: "check_box"
-          })];
-      }
-    };
+    case 'checkbox':
+      return _react.default.createElement(_react.default.Fragment, null, _react.default.createElement(UncheckedCheckboxIcon, {
+        centeredInput: centeredInput,
+        checked: checked,
+        answered: answered,
+        dense: dense
+      }), _react.default.createElement(CheckedCheckboxIcon, {
+        centeredInput: centeredInput,
+        checked: checked,
+        answered: answered,
+        dense: dense
+      }), _react.default.createElement(IndeterminateIcon, {
+        centeredInput: centeredInput,
+        indeterminate: indeterminate,
+        dense: dense
+      }));
   }
+};
 
-  render() {
-    const {
-      answered,
-      checked,
-      correct,
-      cssOverrides,
-      disabled,
-      incorrect,
-      onChange,
-      children,
-      readOnly,
-      type,
-      value,
-      required,
-      name
-    } = this.props;
-    return _react.default.createElement(CCChoice, {
-      correct: correct,
-      cssOverrides: cssOverrides,
-      incorrect: incorrect,
-      disabled: disabled,
-      readOnly: readOnly,
-      answered: answered
-    }, _react.default.createElement(_Icon.Icon, {
-      icon: "cancel",
-      className: "IncorrectIcon"
-    }), _react.default.createElement(_Icon.Icon, {
-      icon: "check_circle",
-      className: "CorrectIcon"
-    }), _react.default.createElement(BBChoiceInput, {
-      disabled: disabled,
-      onChange: onChange,
-      className: "RealInput",
-      checked: checked,
-      type: type,
-      readOnly: readOnly,
-      value: value,
-      required: required,
-      name: name
-    }), this.renderFakeInputIcons(), _react.default.createElement(BBChoiceFakeLabel, {
-      answered: answered,
-      disabled: disabled
-    }, children));
-  }
-
-}
+const Choice = ({
+  answered,
+  centeredInput,
+  checked,
+  correct,
+  cssOverrides,
+  dense,
+  disabled,
+  incorrect,
+  indeterminate,
+  onChange,
+  children,
+  readOnly,
+  type,
+  value,
+  required,
+  name,
+  style,
+  ...domProps
+}) => _react.default.createElement(CCChoice, _extends({
+  style: style,
+  correct: correct,
+  cssOverrides: cssOverrides,
+  incorrect: incorrect,
+  dense: dense,
+  disabled: disabled,
+  readOnly: readOnly,
+  answered: answered,
+  indeterminate: indeterminate
+}, domProps), _react.default.createElement(BBChoiceInput, {
+  disabled: disabled,
+  onChange: onChange,
+  checked: checked,
+  type: type,
+  readOnly: readOnly,
+  value: value,
+  required: required,
+  name: name
+}), _react.default.createElement(IncorrectIcon, {
+  incorrect: incorrect
+}), _react.default.createElement(CorrectIcon, {
+  correct: correct
+}), renderFakeInputIcons(type, centeredInput, checked, answered, dense, indeterminate), _react.default.createElement(BBChoiceFakeLabel, {
+  answered: answered,
+  disabled: disabled
+}, children));
 
 exports.Choice = Choice;
+Choice.defaultProps = {
+  answered: false,
+  centeredInput: false,
+  dense: false,
+  disabled: false,
+  indeterminate: false,
+  correct: false,
+  incorrect: false,
+  checked: false,
+  defaultChecked: false,
+  cssOverrides: '',
+  readOnly: false,
+  value: '',
+  required: false,
+  name: '',
+  key: '',
+  type: 'radio',
+  children: ''
+};

--- a/dist/inputs/TextArea.d.ts
+++ b/dist/inputs/TextArea.d.ts
@@ -1,5 +1,6 @@
 import React, { ChangeEvent, Component } from 'react';
 import { SimpleInterpolation } from 'styled-components';
+export declare const BBTextAreaContainer: import("styled-components").StyledComponent<"label", any, TextAreaProps, never>;
 declare type BBTextAreaContainerProps = {
     cssOverrides?: SimpleInterpolation;
 };

--- a/dist/inputs/TextArea.js
+++ b/dist/inputs/TextArea.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.TextArea = void 0;
+exports.TextArea = exports.BBTextAreaContainer = void 0;
 
 var _react = _interopRequireWildcard(require("react"));
 
@@ -28,6 +28,8 @@ _styledComponents.default.label.withConfig({
 })(({
   cssOverrides
 }) => (0, _styledComponents.css)(["", ";max-width:256px;width:100%;position:relative;", ";"], (0, _exports.flexFlow)(), cssOverrides));
+
+exports.BBTextAreaContainer = BBTextAreaContainer;
 
 const BBTextAreaLabel =
 /*#__PURE__*/

--- a/dist/package.json
+++ b/dist/package.json
@@ -47,8 +47,8 @@
     "react": "^16.8.0",
     "react-datetime": "^2.14.0",
     "react-dom": "^16.8.0",
-    "react-router": "^3.2.0",
     "react-pose": "^4.0.0",
+    "react-router": "^3.2.0",
     "styled-components": "^4.0.0",
     "typelevel-ts": "0.3.4"
   },
@@ -64,9 +64,9 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "7.3.3",
     "@babel/register": "7.4.0",
+    "@types/history": "3.2.1",
     "@types/jest": "24.0.11",
     "@types/lodash": "4.14.110",
-    "@types/history": "3.2.1",
     "@types/react": "16.8.13",
     "@types/react-dom": "16.8.3",
     "@types/react-router": "3",
@@ -76,10 +76,10 @@
     "babel-plugin-styled-components": "1.10.0",
     "fp-ts": "1.17.0",
     "fp-ts-contrib": "0.0.2",
+    "history": "3.2.1",
     "io-ts": "1.7.1",
     "io-ts-types": "0.4.2",
     "lodash": "4.17.11",
-    "history": "3.2.1",
     "monocle-ts": "1.7.1",
     "newtype-ts": "0.2.3",
     "react": "16.8.6",
@@ -89,6 +89,6 @@
     "react-router": "3.2.1",
     "styled-components": "4.2.0",
     "typelevel-ts": "0.3.4",
-    "typescript": "3.3.4000"
+    "typescript": "3.5.1"
   }
 }

--- a/dist/sharedHelpers/SerializableMap.d.ts
+++ b/dist/sharedHelpers/SerializableMap.d.ts
@@ -16,4 +16,4 @@ export declare class SerializableMap<K extends string, V> extends Map<K, V> {
  * SerializableMap constructor function
  *
  */
-export declare const mkSerializableMap: <K extends string, V>(pairs: ReadonlyArray<[K, V]>) => SerializableMap<K, V>;
+export declare const mkSerializableMap: <K extends string, V>(pairs: readonly [K, V][]) => SerializableMap<K, V>;

--- a/dist/sharedHelpers/optics.d.ts
+++ b/dist/sharedHelpers/optics.d.ts
@@ -18,7 +18,7 @@ export declare type ExtractAFromLens<L extends Lens<any, any>> = L extends Lens<
  * A function that generates monocle-ts Lenses for all top-level key-val pairs
  * when passed an object
  */
-export declare const lensesFromRecord: <A extends Record<string, unknown>, K extends keyof A & string, LensRecord extends { [P in K]: Lens<A, A[P]>; }, IndexedLensRecord extends Record<string, Lens<A, A[K]>>>(x: A) => LensRecord;
+export declare const lensesFromRecord: <A, K extends keyof A & string, LensRecord extends { [P in K]: Lens<A, A[P]>; }, IndexedLensRecord extends Record<string, Lens<A, A[K]>>>(x: A) => LensRecord;
 /**
  * Creates an Optional optic for a given index in some Array<A>
  */

--- a/dist/sharedHelpers/taggedUnions.js
+++ b/dist/sharedHelpers/taggedUnions.js
@@ -13,6 +13,10 @@ const mkConstructors = () => (tag, memberTagRecord) => {
   const result = {};
 
   for (const memberTag of Object.keys(memberTagRecord)) {
+    // TODO: any cast due to TS 3.5 upgrade. Not sure how to type better. -dan
+    // tslint:disable-next-line: no-any
+    ;
+
     result[memberTag] = x => {
       const tagPair = {
         [tag]: memberTag
@@ -39,6 +43,10 @@ const mkGuards = () => (tag, memberTagRecord) => {
   const result = {};
 
   for (const memberTag of Object.keys(memberTagRecord)) {
+    // TODO: any cast due to TS 3.5 upgrade. Not sure how to type better. -dan
+    // tslint:disable-next-line: no-any
+    ;
+
     result[memberTag] = member => member[tag] === memberTag;
   }
 

--- a/dist/sharedHelpers/typeGuards.d.ts
+++ b/dist/sharedHelpers/typeGuards.d.ts
@@ -51,3 +51,7 @@ export declare const isObject: (x: unknown) => x is object;
  * Type guard for the `Function` primitive
  */
 export declare const isFunction: (x: unknown) => x is (params: unknown) => void;
+/**
+ * Typeguard for making sure a key is in an object when the object has no index signature
+ */
+export declare function hasKey<O>(obj: O, key: string | number | symbol): key is keyof O;

--- a/dist/sharedHelpers/typeGuards.js
+++ b/dist/sharedHelpers/typeGuards.js
@@ -3,6 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.hasKey = hasKey;
 exports.isFunction = exports.isObject = exports.isNumber = exports.isString = exports.isFalsy = exports.isZero = exports.isEmptyString = exports.isTrue = exports.isFalse = exports.isNotNil = exports.isNil = exports.isUndefined = exports.isNull = void 0;
 
 /**
@@ -106,5 +107,13 @@ const isObject = x => !isNull(x) && typeof x === 'object' && x instanceof Object
 exports.isObject = isObject;
 
 const isFunction = x => x instanceof Function;
+/**
+ * Typeguard for making sure a key is in an object when the object has no index signature
+ */
+
 
 exports.isFunction = isFunction;
+
+function hasKey(obj, key) {
+  return key in obj;
+}

--- a/dist/typography/Mapping.js
+++ b/dist/typography/Mapping.js
@@ -34,7 +34,7 @@ const MappingID =
 _styledComponents.default.span.withConfig({
   displayName: "Mapping__MappingID",
   componentId: "sc-1x0g1sf-1"
-})(["", ";background:", ";color:", ";font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;font-weight:", ";margin-right:5px;padding:1px 2px 0 2px;"], (0, _exports.borderRadius)(_exports.BorderRadius.Small), (0, _exports.getColor)(_exports.Colors.Grey94), (0, _exports.getColor)(_exports.Colors.Black74), _exports.FontWeights.Book);
+})(["", ";background:", ";color:", ";font-family:SFMono-Regular,Consolas,Liberation Mono,Menlo,Courier,monospace;font-weight:600;margin-right:5px;padding:1px 2px 0 2px;"], (0, _exports.borderRadius)(_exports.BorderRadius.Small), (0, _exports.getColor)(_exports.Colors.Grey94), (0, _exports.getColor)(_exports.Colors.Black74));
 /*
  * Types
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simspace/monorail",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "SimSpace Design System",
   "resolutions": {
     "@types/lodash": "4.14.110",

--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "react": "^16.8.0",
     "react-datetime": "^2.14.0",
     "react-dom": "^16.8.0",
-    "react-router": "^3.2.0",
     "react-pose": "^4.0.0",
+    "react-router": "^3.2.0",
     "styled-components": "^4.0.0",
     "typelevel-ts": "0.3.4"
   },
@@ -64,9 +64,9 @@
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "7.3.3",
     "@babel/register": "7.4.0",
+    "@types/history": "3.2.1",
     "@types/jest": "24.0.11",
     "@types/lodash": "4.14.110",
-    "@types/history": "3.2.1",
     "@types/react": "16.8.13",
     "@types/react-dom": "16.8.3",
     "@types/react-router": "3",
@@ -76,10 +76,10 @@
     "babel-plugin-styled-components": "1.10.0",
     "fp-ts": "1.17.0",
     "fp-ts-contrib": "0.0.2",
+    "history": "3.2.1",
     "io-ts": "1.7.1",
     "io-ts-types": "0.4.2",
     "lodash": "4.17.11",
-    "history": "3.2.1",
     "monocle-ts": "1.7.1",
     "newtype-ts": "0.2.3",
     "react": "16.8.6",
@@ -89,6 +89,6 @@
     "react-router": "3.2.1",
     "styled-components": "4.2.0",
     "typelevel-ts": "0.3.4",
-    "typescript": "3.3.4000"
+    "typescript": "3.5.1"
   }
 }

--- a/src/actionsButtons/ActionsButtons.tsx
+++ b/src/actionsButtons/ActionsButtons.tsx
@@ -1,0 +1,91 @@
+import React, { FC, ReactNode } from 'react'
+import { css } from 'styled-components'
+
+import {
+  ActionsMenu,
+  ActionsMenuProps,
+} from '@monorail/actionsMenu/ActionsMenu'
+import { Button } from '@monorail/buttons/Button'
+import { ButtonDisplay, ButtonSize } from '@monorail/buttons/buttonTypes'
+import { IconButton } from '@monorail/buttons/IconButton'
+import { PopOverToggleProps } from '@monorail/popOver/PopOver'
+
+export type ActionsButtonsProps = {
+  display?: ButtonDisplay
+  featuredActions?: Array<
+    Omit<ActionsMenuProps['menuItems'][0], 'featuredAction'>
+  >
+  standardActions?: Array<
+    Omit<ActionsMenuProps['menuItems'][0], 'featuredAction'>
+  >
+  size?: ButtonSize
+  iconOnly?: boolean
+  document?: Document
+  toggle?: (props: PopOverToggleProps) => ReactNode
+}
+
+const combineActions = (
+  standardActions: ActionsButtonsProps['standardActions'] = [],
+  featuredActions: ActionsButtonsProps['featuredActions'] = [],
+) =>
+  featuredActions
+    .map(
+      (action): ActionsMenuProps['menuItems'][0] => ({
+        ...action,
+        featuredAction: true,
+        /**
+         * Remapping onClick to be able to close the action menu.
+         * This wouldn't be necessary if the interfaces were the same
+         */
+        onClick: (parentClick: () => void) => {
+          action.onClick(() => {})
+          parentClick()
+        },
+      }),
+    )
+    .concat(standardActions)
+
+export const ActionsButtons: FC<ActionsButtonsProps> = ({
+  display,
+  document,
+  featuredActions,
+  iconOnly,
+  size,
+  standardActions,
+}) => (
+  <>
+    {featuredActions &&
+      featuredActions.map(action =>
+        iconOnly ? (
+          <IconButton
+            key={`${action.label}-${action.iconName}`}
+            icon={action.iconName}
+            title={action.label}
+            size={size}
+            display={display}
+            onClick={() => action.onClick(() => {})}
+          />
+        ) : (
+          <Button
+            key={`${action.label}-${action.iconName}`}
+            size={size}
+            display={display}
+            iconLeft={action.iconName}
+            // hacky because of the onClick type of ActionMenu's menu items
+            onClick={() => action.onClick(() => {})}
+          >
+            {action.label}
+          </Button>
+        ),
+      )}
+    {standardActions && (
+      <ActionsMenu
+        css={css`
+          margin-left: 8px;
+        `}
+        document={document}
+        menuItems={combineActions(standardActions, featuredActions)}
+      />
+    )}
+  </>
+)

--- a/src/actionsMenu/ActionsMenu.tsx
+++ b/src/actionsMenu/ActionsMenu.tsx
@@ -1,7 +1,9 @@
 import React, { ReactNode } from 'react'
+import { css } from 'styled-components'
 
 import { ButtonDisplay, IconButtonShape } from '@monorail/buttons/buttonTypes'
 import { IconButton } from '@monorail/buttons/IconButton'
+import { Divider } from '@monorail/divider/Divider'
 import { Sizes } from '@monorail/helpers/size'
 import { SimpleListItem } from '@monorail/list/List'
 import { Menu } from '@monorail/menu/Menu'
@@ -20,6 +22,12 @@ export type ActionsMenuProps = {
   menuItems: Array<{
     label: string
     iconName?: string
+    /**
+     * TODO: get rid of the need to have to pass a callback to close the popover.
+     * This onClick should match the signature of all other react onClick.
+     * If we weren't depending on asynchronous behavior in components that are consuming
+     * ActionsMenu we would just be able to stop propagation on the SyntheticEvent
+     */
     onClick: (onClickParent: () => void) => void
     featuredAction?: boolean // Will be implemented later
     children?: ReactNode
@@ -40,38 +48,57 @@ export const ActionsMenu: FCwDP<ActionsMenuProps, DefaultProps> = ({
   menuItems,
   toggle,
   ...domProps
-}) => (
-  <>
-    {menuItems.length > 0 && (
-      <PopOver
-        document={document}
-        popOver={({ onClick, ...otherProps }) => (
-          <Menu onClick={onClick} {...otherProps}>
-            {menuItems.map((menuItem, idx) => (
-              <SimpleListItem
-                key={idx + menuItem.label}
-                size={Sizes.DP32}
-                leftIcon={menuItem.iconName}
-                primaryText={menuItem.label}
-                onClick={e => menuItem.onClick(() => onClick(e))}
-              >
-                {menuItem.children}
-              </SimpleListItem>
-            ))}
-          </Menu>
-        )}
-        toggle={props => toggle({ ...props, ...domProps })}
-      />
-    )}
-  </>
-)
+}) => {
+  const featuredItems = menuItems.filter(x => x.featuredAction)
+  const standardItems = menuItems.filter(x => !x.featuredAction)
+  return (
+    <>
+      {menuItems.length > 0 && (
+        <PopOver
+          document={document}
+          popOver={({ onClick, ...otherProps }) => (
+            <Menu onClick={onClick} {...otherProps}>
+              {featuredItems.map((menuItem, idx) => (
+                <SimpleListItem
+                  key={idx + menuItem.label}
+                  size={Sizes.DP32}
+                  leftIcon={menuItem.iconName}
+                  primaryText={menuItem.label}
+                  onClick={e => menuItem.onClick(() => onClick(e))}
+                >
+                  {menuItem.children}
+                </SimpleListItem>
+              ))}
+              <Divider
+                css={css`
+                  margin: 4px 0 3px;
+                `}
+              />
+              {standardItems.map((menuItem, idx) => (
+                <SimpleListItem
+                  key={idx + menuItem.label}
+                  size={Sizes.DP32}
+                  leftIcon={menuItem.iconName}
+                  primaryText={menuItem.label}
+                  onClick={e => menuItem.onClick(() => onClick(e))}
+                >
+                  {menuItem.children}
+                </SimpleListItem>
+              ))}
+            </Menu>
+          )}
+          toggle={props => toggle({ ...props, ...domProps })}
+        />
+      )}
+    </>
+  )
+}
 
 ActionsMenu.defaultProps = {
   toggle: props => (
     <IconButton
       icon="more_vert"
       display={ButtonDisplay.Chromeless}
-      shape={IconButtonShape.Default}
       {...props}
     />
   ),

--- a/src/appIcon/AppIcon.tsx
+++ b/src/appIcon/AppIcon.tsx
@@ -20,7 +20,7 @@ type AppIconProps = CommonComponentType & {
 // tslint:disable no-unsafe-any
 export const AppIcon = styled(({ appName, cssOverrides, ...otherProps }) => (
   <div {...otherProps}>
-    <Icon icon={appName} />
+    <Icon icon={`${appName}-app`} />
   </div>
 ))<AppIconProps>(
   ({ cssOverrides }) => css`

--- a/src/buttons/Button.tsx
+++ b/src/buttons/Button.tsx
@@ -179,6 +179,7 @@ type FunctionalProps = {
   onMouseUp?: OnClick
   pressed: boolean
   size: ButtonSize
+  title?: string
   type: 'button' | 'reset' | 'submit'
 }
 

--- a/src/filters/Filter.tsx
+++ b/src/filters/Filter.tsx
@@ -18,7 +18,7 @@ import { Menu } from '@monorail/menu/Menu'
 import { PopOver } from '@monorail/popOver/PopOver'
 import { isNil } from '@monorail/sharedHelpers/typeGuards'
 
-const CCFilter = styled.div<CCFilterProps>(
+export const CCFilter = styled.div<CCFilterProps>(
   ({ isActive, cssOverrides }) => css`
     ${isActive
       ? basePrimaryStyles(ThemeColors.BrandSecondary)
@@ -42,7 +42,7 @@ const CCFilter = styled.div<CCFilterProps>(
   `,
 )
 
-const FilterText = styled.span`
+export const FilterText = styled.span`
   ${typography(700, FontSizes.Title5)};
 
   color: currentColor;
@@ -50,7 +50,7 @@ const FilterText = styled.span`
   white-space: nowrap;
 `
 
-const FilterIcon = styled(Icon)`
+export const FilterIcon = styled(Icon)`
   color: currentColor;
 `
 

--- a/src/helpers/color.ts
+++ b/src/helpers/color.ts
@@ -1,6 +1,8 @@
 export enum Colors {
   // Black, Gray, and White.
+  Black12 = 'black12',
   Black24 = 'black24',
+  Black38 = 'black38',
   Black54 = 'black54',
   Black62 = 'black62',
   Black74 = 'black74',
@@ -87,7 +89,9 @@ export const colorHSLAMap = ({
 }): HSLAMapType => {
   const baseColors = {
     // Base Colors
+    [Colors.Black12]: { h: 0, s: 0, l: 0, a: 0.12 * alpha },
     [Colors.Black24]: { h: 0, s: 0, l: 0, a: 0.24 * alpha },
+    [Colors.Black38]: { h: 0, s: 0, l: 0, a: 0.38 * alpha },
     [Colors.Black54]: { h: 0, s: 0, l: 0, a: 0.54 * alpha },
     [Colors.Black62]: { h: 0, s: 0, l: 0, a: 0.62 * alpha },
     [Colors.Black74]: { h: 0, s: 0, l: 0, a: 0.74 * alpha },

--- a/src/hyperLink/BaseLink.tsx
+++ b/src/hyperLink/BaseLink.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react'
+import { Link, LinkProps } from 'react-router'
+
+// BaseLink does prop stripping for styled-components so that we don't have to strip props for every styled-component that uses a link.
+
+export const BaseLink: FC<LinkProps & { className?: string }> = ({
+  onlyActiveOnIndex,
+  to,
+  activeClassName,
+  activeStyle,
+  className,
+  children,
+  onClick,
+}) => (
+  <Link
+    onlyActiveOnIndex={onlyActiveOnIndex}
+    to={to}
+    activeClassName={activeClassName}
+    activeStyle={activeStyle}
+    className={className}
+    onClick={onClick}
+  >
+    {children}
+  </Link>
+)

--- a/src/icon/Icon.tsx
+++ b/src/icon/Icon.tsx
@@ -1,17 +1,8 @@
 import React, { ComponentType, MouseEvent } from 'react'
-import styled, {
-  createGlobalStyle,
-  css,
-  SimpleInterpolation,
-} from 'styled-components'
+import styled, { createGlobalStyle, css } from 'styled-components'
 import { Omit } from 'typelevel-ts'
 
-import {
-  Colors,
-  convertAppNameToString,
-  getColor,
-  isAppName,
-} from '@monorail/helpers/exports'
+import { Colors, getColor } from '@monorail/helpers/exports'
 import { Academy } from '@monorail/icon/custom/Academy'
 import { Admin } from '@monorail/icon/custom/Admin'
 import { Catalog } from '@monorail/icon/custom/Catalog'
@@ -125,9 +116,7 @@ const customIcons: { [key: string]: ComponentType<CustomIconProps> } = {
 
 export const Icon = styled(
   ({ cssOverrides: _cssOverrides, icon, ...otherProps }: IconProps) => {
-    const CustomIcon =
-      customIcons[icon] ||
-      (isAppName(icon) && customIcons[`${convertAppNameToString(icon)}-app`])
+    const CustomIcon = customIcons[icon]
 
     if (CustomIcon) {
       return <CustomIcon {...otherProps} />

--- a/src/inputs/RadioGroup.tsx
+++ b/src/inputs/RadioGroup.tsx
@@ -66,7 +66,9 @@ export const RadioGroup: SFC<Props> = ({
             name={label}
             checked={o.key === value}
             value={o.key}
-            onChange={e => onSelect(o.key, e)}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onSelect(o.key, e)
+            }
             required={required}
             readOnly={false}
           >

--- a/src/inputs/TextArea.tsx
+++ b/src/inputs/TextArea.tsx
@@ -16,7 +16,7 @@ import { isNil } from '@monorail/sharedHelpers/typeGuards'
  * Styles
  */
 
-const BBTextAreaContainer = styled.label<TextAreaProps>(
+export const BBTextAreaContainer = styled.label<TextAreaProps>(
   ({ cssOverrides }) => css`
     ${flexFlow()};
 

--- a/src/sharedHelpers/optics.ts
+++ b/src/sharedHelpers/optics.ts
@@ -40,7 +40,7 @@ export type ExtractAFromLens<L extends Lens<any, any>> = L extends Lens<
  * when passed an object
  */
 export const lensesFromRecord = <
-  A extends Record<string, unknown>,
+  A,
   K extends keyof A & string,
   LensRecord extends { [P in K]: Lens<A, A[P]> },
   IndexedLensRecord extends Record<string, Lens<A, A[K]>>

--- a/src/sharedHelpers/taggedUnions.ts
+++ b/src/sharedHelpers/taggedUnions.ts
@@ -66,7 +66,9 @@ export const mkConstructors = <A extends object>() => <
   const result = {} as StringIndexed<Constructors<A, DataConstructorTagKey>>
 
   for (const memberTag of Object.keys(memberTagRecord)) {
-    result[memberTag] = (
+    // TODO: any cast due to TS 3.5 upgrade. Not sure how to type better. -dan
+    // tslint:disable-next-line: no-any
+    ;(result as any)[memberTag] = (
       x: Omit<
         TaggedUnionMember<
           A,
@@ -154,7 +156,9 @@ export const mkGuards = <A extends object>() => <
     }
   >
   for (const memberTag of Object.keys(memberTagRecord)) {
-    result[memberTag] = (
+    // TODO: any cast due to TS 3.5 upgrade. Not sure how to type better. -dan
+    // tslint:disable-next-line: no-any
+    ;(result as any)[memberTag] = (
       member: A,
     ): member is Extract<
       A,

--- a/src/sharedHelpers/typeGuards.ts
+++ b/src/sharedHelpers/typeGuards.ts
@@ -74,3 +74,13 @@ export const isObject = (x: unknown): x is object =>
  */
 export const isFunction = (x: unknown): x is (params: unknown) => void =>
   x instanceof Function
+
+/**
+ * Typeguard for making sure a key is in an object when the object has no index signature
+ */
+export function hasKey<O>(
+  obj: O,
+  key: string | number | symbol,
+): key is keyof O {
+  return key in obj
+}

--- a/src/typography/Mapping.tsx
+++ b/src/typography/Mapping.tsx
@@ -6,7 +6,6 @@ import {
   BorderRadius,
   Colors,
   FontSizes,
-  FontWeights,
   getColor,
   typography,
 } from '@monorail/helpers/exports'
@@ -32,7 +31,7 @@ export const MappingID = styled.span`
   color: ${getColor(Colors.Black74)};
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
     monospace;
-  font-weight: ${FontWeights.Book};
+  font-weight: 600;
   margin-right: 5px;
   padding: 1px 2px 0 2px;
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -853,9 +853,9 @@
   integrity sha512-iXYLa6olt4tnsCA+ZXeP6eEW3tk1SulWeYyP/yooWfAtXjozqXgtX4+XUtMuOCfYjKGz3F34++qUc3Q+TJuIIw==
 
 "@types/node@^10.0.5":
-  version "10.14.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.7.tgz#1854f0a9aa8d2cd6818d607b3d091346c6730362"
-  integrity sha512-on4MmIDgHXiuJDELPk1NFaKVUxxCFr37tm8E9yN6rAiF5Pzp/9bBfBHkoexqRiY+hk/Z04EJU9kKEb59YqJ82A==
+  version "10.14.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.8.tgz#fe444203ecef1162348cd6deb76c62477b2cc6e9"
+  integrity sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==
 
 "@types/prop-types@*":
   version "15.7.1"
@@ -1074,13 +1074,13 @@ braces@^2.3.1, braces@^2.3.2:
     to-regex "^3.0.1"
 
 browserslist@^4.5.2, browserslist@^4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.0.tgz#5274028c26f4d933d5b1323307c1d1da5084c9ff"
-  integrity sha512-Jk0YFwXBuMOOol8n6FhgkDzn3mY9PYLYGk29zybF05SbRTsMgPqmTNeQQhOghCxq5oFqAXE3u4sYddr4C0uRhg==
+  version "4.6.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.6.1.tgz#ee5059b1aec18cbec9d055d6cb5e24ae50343a9b"
+  integrity sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==
   dependencies:
-    caniuse-lite "^1.0.30000967"
-    electron-to-chromium "^1.3.133"
-    node-releases "^1.1.19"
+    caniuse-lite "^1.0.30000971"
+    electron-to-chromium "^1.3.137"
+    node-releases "^1.1.21"
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1126,10 +1126,10 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30000967:
-  version "1.0.30000971"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000971.tgz#d1000e4546486a6977756547352bc96a4cfd2b13"
-  integrity sha512-TQFYFhRS0O5rdsmSbF1Wn+16latXYsQJat66f7S7lizXW1PVpWJeZw9wqqVLIjuxDRz7s7xRUj13QCfd8hKn6g==
+caniuse-lite@^1.0.30000971:
+  version "1.0.30000974"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz#b7afe14ee004e97ce6dc73e3f878290a12928ad8"
+  integrity sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==
 
 chalk@^2.0.0:
   version "2.4.2"
@@ -1366,10 +1366,10 @@ detect-libc@^1.0.2:
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
 
-electron-to-chromium@^1.3.133:
-  version "1.3.137"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.137.tgz#ba7c88024984c038a5c5c434529aabcea7b42944"
-  integrity sha512-kGi32g42a8vS/WnYE7ELJyejRT7hbr3UeOOu0WeuYuQ29gCpg9Lrf6RdcTQVXSt/v0bjCfnlb/EWOOsiKpTmkw==
+electron-to-chromium@^1.3.137:
+  version "1.3.150"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.150.tgz#afb972b53a702b37c76db843c39c967e9f68464b"
+  integrity sha512-5wuYlaXhXbBvavSTij5ZyidICB6sAK/1BwgZZoPCgsniid1oDgzVvDOV/Dw6J25lKV9QZ9ZdQCp8MEfF0/OIKA==
 
 encoding@^0.1.11:
   version "0.1.12"
@@ -2066,7 +2066,7 @@ minimist@^1.2.0:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
-minipass@^2.2.1, minipass@^2.3.4:
+minipass@^2.2.1, minipass@^2.3.5:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-2.3.5.tgz#cacebe492022497f656b0f0f51e2682a9ed2d848"
   integrity sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==
@@ -2074,7 +2074,7 @@ minipass@^2.2.1, minipass@^2.3.4:
     safe-buffer "^5.1.2"
     yallist "^3.0.0"
 
-minizlib@^1.1.1:
+minizlib@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/minizlib/-/minizlib-1.2.1.tgz#dd27ea6136243c7c880684e8672bb3a45fd9b614"
   integrity sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==
@@ -2107,9 +2107,9 @@ ms@2.0.0:
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
 ms@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
-  integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
+  integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
 nan@^2.12.1:
   version "2.14.0"
@@ -2179,10 +2179,10 @@ node-pre-gyp@^0.12.0:
     semver "^5.3.0"
     tar "^4"
 
-node-releases@^1.1.19:
-  version "1.1.21"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.21.tgz#46c86f9adaceae4d63c75d3c2f2e6eee618e55f3"
-  integrity sha512-TwnURTCjc8a+ElJUjmDqU6+12jhli1Q61xOQmdZ7ECZVBZuQpN/1UnembiIHDM1wCcfLvh5wrWXUF5H6ufX64Q==
+node-releases@^1.1.21:
+  version "1.1.23"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.23.tgz#de7409f72de044a2fa59c097f436ba89c39997f0"
+  integrity sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==
   dependencies:
     semver "^5.3.0"
 
@@ -2660,9 +2660,9 @@ resolve-url@^0.2.1:
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
 resolve@^1.3.2, resolve@^1.4.0, resolve@^1.8.1:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
-  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
   dependencies:
     path-parse "^1.0.6"
 
@@ -2714,9 +2714,9 @@ semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
 
 semver@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.0.tgz#e95dc415d45ecf03f2f9f83b264a6b11f49c0cca"
-  integrity sha512-kCqEOOHoBcFs/2Ccuk4Xarm/KiWRSLEX9CAZF8xkJ6ZPlIoTZ8V5f7J16vYLJqDbR7KrxTJpR2lqjIEm2Qx9cQ==
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.1.1.tgz#53f53da9b30b2103cd4f15eab3a18ecbcb210c9b"
+  integrity sha512-rWYq2e5iYW+fFe/oPPtYJxYgjBm8sC4rmoGdUOgBB7VnwKt6HrL793l2voH1UlsyYZpJ4g0wfjnTEO1s1NP2eQ==
 
 set-blocking@~2.0.0:
   version "2.0.0"
@@ -2942,17 +2942,17 @@ supports-color@^5.3.0, supports-color@^5.5.0:
     has-flag "^3.0.0"
 
 tar@^4:
-  version "4.4.8"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.8.tgz#b19eec3fde2a96e64666df9fdb40c5ca1bc3747d"
-  integrity sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==
+  version "4.4.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.10.tgz#946b2810b9a5e0b26140cf78bea6b0b0d689eba1"
+  integrity sha512-g2SVs5QIxvo6OLp0GudTqEf05maawKUxXru104iaayWA09551tFCTI8f1Asb4lPfkBr91k07iL4c11XO3/b0tA==
   dependencies:
     chownr "^1.1.1"
     fs-minipass "^1.2.5"
-    minipass "^2.3.4"
-    minizlib "^1.1.1"
+    minipass "^2.3.5"
+    minizlib "^1.2.1"
     mkdirp "^0.5.0"
     safe-buffer "^5.1.2"
-    yallist "^3.0.2"
+    yallist "^3.0.3"
 
 to-fast-properties@^2.0.0:
   version "2.0.0"
@@ -3004,10 +3004,10 @@ typelevel-ts@0.3.4:
   resolved "https://registry.yarnpkg.com/typelevel-ts/-/typelevel-ts-0.3.4.tgz#12593629dd7515f06ef9efc9930d683c51233654"
   integrity sha512-Np19x563BJZ1ZI0R2LVQQ9LSyMLsk0wBLF+kd6g3mDPmCtqK0IKwzAze/ChEtFNNS810dalTaUCFG2uBrk7XXQ==
 
-typescript@3.3.4000:
-  version "3.3.4000"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
-  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
+typescript@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"
@@ -3099,7 +3099,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-yallist@^3.0.0, yallist@^3.0.2:
+yallist@^3.0.0, yallist@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.3.tgz#b4b049e314be545e3ce802236d6cd22cd91c3de9"
   integrity sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==


### PR DESCRIPTION
**Week 23 Release**

Update to Typescript 3.5.1

`src/actionsButtons/ActionsButtons.tsx`



*   Wrapper for ActionMenu that gives you featured actions that either work as Buttons or IconButtons.

`src/actionsMenu/ActionsMenu.tsx`



*   Update to work with featured actions that appear at the top of the menu.

`src/buttons/Button.tsx `



*   Add `title` prop so Buttons can have hover text

`src/helpers/color.ts`



*   Add `Colors.Black12`
*   Add `Colors.Black38`

`src/inputs/RadioGroup.tsx `



*   Resolve type error

`src/inputs/Choice.tsx`



*   Change to functional component.
*   Icon styling logic no longer uses `className`s. Instead, styled components are rendered conditionally by `renderFakeInputIcons`.
*   Now has a ``dense`` prop which applies half the padding.
*   Now has a ``centeredInput`` prop. Default is flush with the top line of text.
*   Now has an ``indeterminate`` prop.

`src/icon/Icon.tsx `



*   Move App Name conversion to `AppIcon.tsx`

`src/appIcon/AppIcon.tsx`



*   Move App Name conversion from `Icon.tsx`

`src/hyperLink/BaseLink.tsx`



*   Added new BaseLink to simplify prop stripping when you want to use a component as a React Router Link, eg: \
``` \
<Button as={BaseLink} to=”/home”>Go Home</Button> \
``` 