### PR TITLE
Monorail Release v0.0.21  - 'Amrheins'

### DIFF
--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simspace/monorail",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "SimSpace Design System",
   "resolutions": {
     "@devexperts/remote-data-ts": "0.6.0",

--- a/dist/pageComponents/errorPage/ErrorPage.js
+++ b/dist/pageComponents/errorPage/ErrorPage.js
@@ -106,7 +106,7 @@ var _StyledButton =
 (0, _styledComponents.default)(_Button.Button).withConfig({
   displayName: "ErrorPage___StyledButton",
   componentId: "jn137y-6"
-})(["&&{margin-top:24px;}"]);
+})(["&&{margin-top:24px;color:", ";}"], p => p._css);
 
 class ErrorPage extends _react.Component {
   render() {
@@ -117,7 +117,8 @@ class ErrorPage extends _react.Component {
     } = this.props;
     return _react.default.createElement(CCErrorPage, null, errorIcon[errorType], _react.default.createElement(Title, null, title ? title : errorTitle[errorType]), _react.default.createElement(ErrorMessage, null, errorMessage ? errorMessage : errorMsg[errorType]), _react.default.createElement(_StyledButton, {
       passedAs: _BaseLink.BaseLink,
-      to: '/'
+      to: '/',
+      _css: (0, _exports.getColor)(_exports.Colors.White)
     }, "Take Me Home"));
   }
 

--- a/dist/visualComponents/inputs/TextArea.d.ts
+++ b/dist/visualComponents/inputs/TextArea.d.ts
@@ -1,7 +1,7 @@
-import React, { ChangeEvent, FC } from 'react';
-import { SimpleInterpolation } from 'styled-components';
 import { DisplayType } from '@monorail/visualComponents/inputs/inputTypes';
 import { ErrorProps } from '@monorail/visualComponents/inputs/StdErr';
+import React, { ChangeEvent, FC, KeyboardEvent } from 'react';
+import { SimpleInterpolation } from 'styled-components';
 export declare const TextAreaContainer: import("styled-components").StyledComponent<"label", any, TextAreaContainerProps & {
     display?: DisplayType | undefined;
 }, never>;
@@ -17,6 +17,7 @@ declare type TextAreaInputProps = {
     height?: number;
     label?: string | number;
     onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void;
+    onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void;
     placeholder?: string;
     readOnly?: boolean;
     required?: boolean;
@@ -26,6 +27,7 @@ declare type TextAreaInputProps = {
     htmlValidation?: boolean;
     hideStdErr?: boolean;
     display?: DisplayType;
+    textareaRef?: React.RefObject<HTMLTextAreaElement>;
 } & ErrorProps;
 export declare type TextAreaProps = TextAreaContainerProps & TextAreaInputProps;
 export declare const TextArea: FC<TextAreaProps>;

--- a/dist/visualComponents/inputs/TextArea.js
+++ b/dist/visualComponents/inputs/TextArea.js
@@ -5,10 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 exports.TextArea = exports.TextAreaInput = exports.TextAreaContainer = void 0;
 
-var _react = _interopRequireWildcard(require("react"));
-
-var _styledComponents = _interopRequireWildcard(require("styled-components"));
-
 var _exports = require("../../helpers/exports");
 
 var _typeGuards = require("../../sharedHelpers/typeGuards");
@@ -20,6 +16,10 @@ var _Label = require("./Label");
 var _StdErr = require("./StdErr");
 
 var _ViewInput = require("./ViewInput");
+
+var _react = _interopRequireWildcard(require("react"));
+
+var _styledComponents = _interopRequireWildcard(require("styled-components"));
 
 function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
 
@@ -73,6 +73,7 @@ const TextArea = props => {
     height,
     label,
     onChange,
+    onKeyDown,
     placeholder,
     readOnly,
     required,
@@ -84,9 +85,11 @@ const TextArea = props => {
     err,
     msg,
     hideStdErr = false,
+    textareaRef,
     ...otherProps
   } = props;
-  const textArea = (0, _react.useRef)(null);
+  const internalRef = (0, _react.useRef)(null);
+  const textArea = textareaRef !== null && textareaRef !== void 0 ? textareaRef : internalRef;
 
   const setCompactHeight = () => {
     if (compact && textArea) {
@@ -127,6 +130,7 @@ const TextArea = props => {
     height: height,
     ref: textArea,
     onChange: onCompactChange,
+    onKeyDown: onKeyDown,
     placeholder: placeholder,
     readOnly: readOnly,
     required: htmlValidation && required,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@simspace/monorail",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "SimSpace Design System",
   "resolutions": {
     "@devexperts/remote-data-ts": "0.6.0",

--- a/src/pageComponents/errorPage/ErrorPage.tsx
+++ b/src/pageComponents/errorPage/ErrorPage.tsx
@@ -128,6 +128,7 @@ export class ErrorPage extends Component<ErrorPageProps> {
             css={css`
               && {
                 margin-top: 24px;
+                color: ${getColor(Colors.White)}; /* override .admin a color */
               }
             `}
             passedAs={BaseLink}

--- a/src/visualComponents/inputs/TextArea.tsx
+++ b/src/visualComponents/inputs/TextArea.tsx
@@ -1,6 +1,3 @@
-import React, { ChangeEvent, FC, useLayoutEffect, useRef } from 'react'
-import styled, { css, SimpleInterpolation } from 'styled-components'
-
 import {
   baseErrorBorderStyles,
   borderRadius,
@@ -16,6 +13,15 @@ import { DisplayType } from '@monorail/visualComponents/inputs/inputTypes'
 import { Label } from '@monorail/visualComponents/inputs/Label'
 import { ErrorProps, StdErr } from '@monorail/visualComponents/inputs/StdErr'
 import { ViewInput } from '@monorail/visualComponents/inputs/ViewInput'
+import React, {
+  ChangeEvent,
+  FC,
+  KeyboardEvent,
+  useLayoutEffect,
+  useRef,
+} from 'react'
+import styled, { css, SimpleInterpolation } from 'styled-components'
+
 /*
  * Styles
  */
@@ -104,6 +110,7 @@ type TextAreaInputProps = {
   height?: number
   label?: string | number
   onChange?: (event: ChangeEvent<HTMLTextAreaElement>) => void
+  onKeyDown?: (event: KeyboardEvent<HTMLTextAreaElement>) => void
   placeholder?: string
   readOnly?: boolean
   required?: boolean
@@ -113,6 +120,7 @@ type TextAreaInputProps = {
   htmlValidation?: boolean
   hideStdErr?: boolean
   display?: DisplayType
+  textareaRef?: React.RefObject<HTMLTextAreaElement>
 } & ErrorProps
 
 export type TextAreaProps = TextAreaContainerProps & TextAreaInputProps
@@ -131,6 +139,7 @@ export const TextArea: FC<TextAreaProps> = props => {
     height,
     label,
     onChange,
+    onKeyDown,
     placeholder,
     readOnly,
     required,
@@ -142,10 +151,12 @@ export const TextArea: FC<TextAreaProps> = props => {
     err,
     msg,
     hideStdErr = false,
+    textareaRef,
     ...otherProps
   } = props
 
-  const textArea = useRef<HTMLTextAreaElement>(null)
+  const internalRef = useRef<HTMLTextAreaElement>(null)
+  const textArea = textareaRef ?? internalRef
 
   const setCompactHeight = () => {
     if (compact && textArea) {
@@ -191,6 +202,7 @@ export const TextArea: FC<TextAreaProps> = props => {
             height={height}
             ref={textArea}
             onChange={onCompactChange}
+            onKeyDown={onKeyDown}
             placeholder={placeholder}
             readOnly={readOnly}
             required={htmlValidation && required}


### PR DESCRIPTION
**Monorail Release v0.0.21  - Amrheins**

![image](https://user-images.githubusercontent.com/3724010/75567422-7f08f180-5a1f-11ea-992d-ee2994dc89d5.png)


`src/pageComponents/errorPage/ErrorPage.tsx`



*   Add `color` CSS to manually override colors being inherited from Bootstrap

`src/visualComponents/inputs/TextArea.tsx`



*   Add `onKeyDown` prop to recognize keystroke actions in the `TextArea`. E.g. `key === enter` to `submit()`