### PR TITLE
fix: list item avatar dimensions

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/ListItemAvatar/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/ListItemAvatar/themeOverrides.ts
@@ -5,8 +5,6 @@ export const MonorailListItemAvatarOverrides: Components<Theme>['MuiListItemAvat
     defaultProps: {},
     styleOverrides: {
       root: ({ theme }) => ({
-        width: theme.spacing(8),
-        height: theme.spacing(8),
         paddingTop: theme.spacing(0),
         paddingBottom: theme.spacing(0),
       }),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
Component: `ListItemAvatar`
Theme: Meteor

Removes fixed width and height to adapt to the child `Avatar`'s size.

## Before

![image](https://github.com/Simspace/monorail/assets/35754959/fe013971-f51b-416e-be96-3a039b1a01d5)

## After

![image](https://github.com/Simspace/monorail/assets/35754959/f3e759dc-0af6-4d2e-9510-8301d1626b75)
