### PR TITLE
[UXE-80] IconButton: Re-enable secondary color variant

### DIFF
--- a/packages/components/src/IconButton/IconButton.tsx
+++ b/packages/components/src/IconButton/IconButton.tsx
@@ -3,12 +3,6 @@ import { IconButton as MuiIconButton } from '@mui/material'
 
 import type { ExtendButtonBase, OverrideProps } from '@monorail/types'
 
-declare module '@mui/material/IconButton' {
-  interface IconButtonPropsColorOverrides {
-    secondary: false
-  }
-}
-
 export type IconButtonProps<
   D extends React.ElementType = IconButtonTypeMap['defaultComponent'],
   P = {},

--- a/packages/storybook/src/IconButton/IconButton.stories.tsx
+++ b/packages/storybook/src/IconButton/IconButton.stories.tsx
@@ -177,6 +177,7 @@ export const Shapes = story<IconButtonProps>(args => (
 const colors = [
   'inherit',
   'primary',
+  'secondary',
   'default',
   'info',
   'success',

--- a/packages/storybook/src/IconButton/IconButton.stories.tsx
+++ b/packages/storybook/src/IconButton/IconButton.stories.tsx
@@ -12,20 +12,47 @@ import { story } from '../helpers/storybook.js'
  * Metadata for IconButton stories - update/extend as needed
  */
 export default { title: 'Inputs/IconButton', component: IconButton }
-/**
- * Story template (edit/remove by hand if needed)
- *
- * Note: there should be at least one "Default" story that uses this template with the "story" function.
- * The Template and "story" function allow the story to be setup so that it works with the Controls addon and docgen
- */
+
+const colors = [
+  'inherit',
+  'primary',
+  'secondary',
+  'default',
+  'info',
+  'success',
+  'warning',
+  'error',
+] as const
+
+const argTypes = {
+  variant: {
+    options: ['contained', 'outlined', 'chromeless'],
+    control: { type: 'radio' },
+  },
+  color: {
+    options: colors,
+    control: { type: 'select' },
+  },
+  size: {
+    options: ['small', 'medium', 'large'],
+    control: { type: 'radio' },
+  },
+  shape: {
+    options: ['circular', 'rounded'],
+    control: { type: 'radio' },
+  },
+  disabled: { control: { type: 'boolean' } },
+}
+
 const Template = story<IconButtonProps>(
-  (args: Partial<IconButtonProps>) => (
+  args => (
     <IconButton aria-label="default" {...args}>
-      <DeleteIcon />
+      <DeleteIcon fontSize="inherit" />
     </IconButton>
   ),
   {
     args: {},
+    argTypes,
     muiName: 'MuiIconButton',
   },
 )
@@ -47,6 +74,7 @@ export const Showcase = story<IconButtonProps>(
     </Stack>
   ),
   {
+    argTypes,
     parameters: {
       docs: {
         description: {
@@ -59,34 +87,37 @@ Icons are also appropriate for toggle buttons that allow a single choice to be s
   },
 )
 
-export const Variants = story<IconButtonProps>(args => (
-  <Stack direction="row" spacing={4}>
-    <IconButton
-      aria-label="delete"
-      variant="chromeless"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-    <IconButton
-      aria-label="delete"
-      variant="outlined"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-    <IconButton
-      aria-label="delete"
-      variant="contained"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-  </Stack>
-))
+export const Variants = story<IconButtonProps>(
+  args => (
+    <Stack direction="row" spacing={4}>
+      <IconButton
+        aria-label="delete"
+        variant="chromeless"
+        color="primary"
+        {...args}
+      >
+        <DeleteIcon />
+      </IconButton>
+      <IconButton
+        aria-label="delete"
+        variant="outlined"
+        color="primary"
+        {...args}
+      >
+        <DeleteIcon />
+      </IconButton>
+      <IconButton
+        aria-label="delete"
+        variant="contained"
+        color="primary"
+        {...args}
+      >
+        <DeleteIcon />
+      </IconButton>
+    </Stack>
+  ),
+  { argTypes },
+)
 
 export const Sizes = story<IconButtonProps>(
   args => (
@@ -121,6 +152,7 @@ export const Sizes = story<IconButtonProps>(
     </Stack>
   ),
   {
+    argTypes,
     parameters: {
       docs: {
         description: {
@@ -133,57 +165,45 @@ Use fontSize="inherit" for the icon when using size="small" or size="large". fon
   },
 )
 
-export const Shapes = story<IconButtonProps>(args => (
-  <Stack direction="row" spacing={4}>
-    <IconButton
-      aria-label="delete"
-      shape="circular"
-      variant="outlined"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-    <IconButton
-      aria-label="delete"
-      shape="rounded"
-      variant="outlined"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-    <IconButton
-      aria-label="delete"
-      shape="circular"
-      variant="contained"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-    <IconButton
-      aria-label="delete"
-      shape="rounded"
-      variant="contained"
-      color="primary"
-      {...args}
-    >
-      <DeleteIcon />
-    </IconButton>
-  </Stack>
-))
-
-const colors = [
-  'inherit',
-  'primary',
-  'secondary',
-  'default',
-  'info',
-  'success',
-  'warning',
-  'error',
-] as const
+export const Shapes = story<IconButtonProps>(
+  () => (
+    <Stack direction="row" spacing={4}>
+      <IconButton
+        aria-label="delete"
+        shape="circular"
+        variant="outlined"
+        color="primary"
+      >
+        <DeleteIcon />
+      </IconButton>
+      <IconButton
+        aria-label="delete"
+        shape="rounded"
+        variant="outlined"
+        color="primary"
+      >
+        <DeleteIcon />
+      </IconButton>
+      <IconButton
+        aria-label="delete"
+        shape="circular"
+        variant="contained"
+        color="primary"
+      >
+        <DeleteIcon />
+      </IconButton>
+      <IconButton
+        aria-label="delete"
+        shape="rounded"
+        variant="contained"
+        color="primary"
+      >
+        <DeleteIcon />
+      </IconButton>
+    </Stack>
+  ),
+  { argTypes },
+)
 
 export const Colors = story<IconButtonProps>(
   () => (

--- a/packages/storybook/src/theme/palette/SemanticColors.stories.tsx
+++ b/packages/storybook/src/theme/palette/SemanticColors.stories.tsx
@@ -154,35 +154,6 @@ export const SemanticColors = () => {
     colorValue: theme.palette.grey[shade as keyof Color],
   }))
 
-  const secondaryColors: Array<ColorTokenRowProps> = [
-    {
-      token: `.light`,
-      colorValue: theme.palette.secondary.light,
-      figmaStyle: `secondary/light`,
-      description:
-        'Use to achieve lower contrast on components with Strong Emphasis. Don’t use for state colors.',
-    },
-    {
-      token: `.main`,
-      colorValue: theme.palette.secondary.main,
-      figmaStyle: `secondary/main`,
-    },
-    {
-      token: `.dark`,
-      colorValue: theme.palette.secondary.dark,
-      figmaStyle: `secondary/dark`,
-      description:
-        'Use to achieve higher contrast on components with Strong Emphasis. Don’t use for state colors.',
-    },
-    {
-      token: `.contrastText`,
-      colorValue: theme.palette.secondary.contrastText,
-      figmaStyle: `secondary/contrastText`,
-      description:
-        'Use for contrast text and icons on components with Strong Emphasis.',
-    },
-  ]
-
   const sentiment = (
     alias: ColorTokenTableProps['alias'],
     paletteColor: PaletteColor,
@@ -334,18 +305,12 @@ export const SemanticColors = () => {
         )
       case 'secondary':
         return (
-          <>
-            <Box mb={10}>
-              <Typography variant="h2" gutterBottom>
-                {`Secondary Colors`}
-              </Typography>
-              <Typography gutterBottom>{`theme.palette.secondary`}</Typography>
-            </Box>
-            <ColorTokenTable
-              colorMetadata={secondaryColors}
-              rawColorObj={rawColorMapping}
-            />
-          </>
+          <Sentiment
+            alias={alias}
+            sentiment={sentiment('secondary', theme.palette.secondary)}
+            colorMode={colorMode}
+            rawColorMapping={rawColorMapping}
+          />
         )
       case 'default':
         return (

--- a/packages/themes/src/classic/theme/dark.ts
+++ b/packages/themes/src/classic/theme/dark.ts
@@ -5,7 +5,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme, lighten } from '@mui/material'
+import { alpha, createTheme, darken } from '@mui/material'
 
 import { baseTheme } from './baseTheme.js'
 import { getThemeComponents } from './themeComponents.js'
@@ -43,6 +43,8 @@ export enum RawColor {
   Blue600 = '#1465FF',
   Blue700 = '#1050CB',
   Blue800 = '#0C3D9C',
+  Blue900 = '#1A2974',
+  Blue950 = '#161C4F',
 
   Orange050 = '#FFF8F0',
   Orange100 = '#FFE6C7',
@@ -273,12 +275,51 @@ const palette: PaletteOptions = {
       600: RawColor.Blue600,
       700: RawColor.Blue700,
       800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
     },
   },
   secondary: {
-    light: lighten('#0C3D99', 0.5),
-    main: '#0C3D99',
-    dark: '#161C4F',
+    light: RawColor.Blue900,
+    main: RawColor.Blue800,
+    dark: RawColor.Blue700,
+    hover: darken(RawColor.Blue800, action.hoverOpacity),
+    active: darken(RawColor.Blue800, action.activatedOpacity),
+    contrastText: RawColor.White,
+
+    lowEmphasis: {
+      light: RawColor.Blue950,
+      main: RawColor.Grey900,
+      dark: RawColor.Blue800,
+      contrastText: RawColor.Blue300,
+      hover: alpha(RawColor.Blue800, action.hoverOpacity),
+      active: alpha(RawColor.Blue800, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Blue800,
+      main: RawColor.Blue500,
+      dark: RawColor.Blue400,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      50: RawColor.Blue050,
+      100: RawColor.Blue100,
+      200: RawColor.Blue200,
+      300: RawColor.Blue300,
+      400: RawColor.Blue400,
+      500: RawColor.Blue500,
+      600: RawColor.Blue600,
+      700: RawColor.Blue700,
+      800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
+    },
   },
   default: {
     light: RawColor.Grey700,

--- a/packages/themes/src/classic/theme/light.ts
+++ b/packages/themes/src/classic/theme/light.ts
@@ -5,7 +5,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme } from '@mui/material'
+import { alpha, createTheme, lighten } from '@mui/material'
 
 import { baseTheme } from './baseTheme.js'
 import { getThemeComponents } from './themeComponents.js'
@@ -43,6 +43,8 @@ export enum RawColor {
   Blue600 = '#1465FF',
   Blue700 = '#1050CB',
   Blue800 = '#0C3D9C',
+  Blue900 = '#1A2974',
+  Blue950 = '#161C4F',
 
   Orange050 = '#FFF8F0',
   Orange100 = '#FFE6C7',
@@ -272,12 +274,51 @@ const palette: PaletteOptions = {
       600: RawColor.Blue600,
       700: RawColor.Blue700,
       800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue800,
     },
   },
   secondary: {
-    light: '#0C3D99',
-    main: '#1A2974',
-    dark: '#161C4F',
+    light: RawColor.Blue800,
+    main: RawColor.Blue900,
+    dark: RawColor.Blue950,
+    hover: RawColor.Blue800,
+    active: lighten(RawColor.Blue800, action.activatedOpacity),
+    contrastText: RawColor.White,
+
+    lowEmphasis: {
+      light: RawColor.Blue050,
+      main: RawColor.Blue100,
+      dark: RawColor.Blue300,
+      contrastText: RawColor.Blue800,
+      hover: alpha(RawColor.Blue800, action.hoverOpacity),
+      active: alpha(RawColor.Blue800, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Blue700,
+      main: RawColor.Blue800,
+      dark: RawColor.Blue950,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      50: RawColor.Blue050,
+      100: RawColor.Blue100,
+      200: RawColor.Blue200,
+      300: RawColor.Blue300,
+      400: RawColor.Blue400,
+      500: RawColor.Blue500,
+      600: RawColor.Blue600,
+      700: RawColor.Blue700,
+      800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
+    },
   },
   default: {
     light: RawColor.Grey400,

--- a/packages/themes/src/legacy/theme/dark.ts
+++ b/packages/themes/src/legacy/theme/dark.ts
@@ -5,7 +5,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme, lighten } from '@mui/material'
+import { alpha, createTheme, darken } from '@mui/material'
 
 import { baseTheme } from './baseTheme.js'
 import { getThemeComponents } from './themeComponents.js'
@@ -43,6 +43,8 @@ export enum RawColor {
   Blue600 = '#1465FF',
   Blue700 = '#1050CB',
   Blue800 = '#0C3D9C',
+  Blue900 = '#1A2974',
+  Blue950 = '#161C4F',
 
   Orange050 = '#FFF8F0',
   Orange100 = '#FFE6C7',
@@ -273,12 +275,51 @@ const palette: PaletteOptions = {
       600: RawColor.Blue600,
       700: RawColor.Blue700,
       800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
     },
   },
   secondary: {
-    light: lighten('#0C3D99', 0.5),
-    main: '#0C3D99',
-    dark: '#161C4F',
+    light: RawColor.Blue900,
+    main: RawColor.Blue800,
+    dark: RawColor.Blue700,
+    hover: darken(RawColor.Blue800, action.hoverOpacity),
+    active: darken(RawColor.Blue800, action.activatedOpacity),
+    contrastText: RawColor.White,
+
+    lowEmphasis: {
+      light: RawColor.Blue950,
+      main: RawColor.Grey900,
+      dark: RawColor.Blue800,
+      contrastText: RawColor.Blue300,
+      hover: alpha(RawColor.Blue800, action.hoverOpacity),
+      active: alpha(RawColor.Blue800, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Blue800,
+      main: RawColor.Blue500,
+      dark: RawColor.Blue400,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      50: RawColor.Blue050,
+      100: RawColor.Blue100,
+      200: RawColor.Blue200,
+      300: RawColor.Blue300,
+      400: RawColor.Blue400,
+      500: RawColor.Blue500,
+      600: RawColor.Blue600,
+      700: RawColor.Blue700,
+      800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
+    },
   },
   default: {
     light: RawColor.Grey700,

--- a/packages/themes/src/legacy/theme/light.ts
+++ b/packages/themes/src/legacy/theme/light.ts
@@ -5,7 +5,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme } from '@mui/material'
+import { alpha, createTheme, lighten } from '@mui/material'
 
 import { baseTheme } from './baseTheme.js'
 import { getThemeComponents } from './themeComponents.js'
@@ -43,6 +43,8 @@ export enum RawColor {
   Blue600 = '#1465FF',
   Blue700 = '#1050CB',
   Blue800 = '#0C3D9C',
+  Blue900 = '#1A2974',
+  Blue950 = '#161C4F',
 
   Orange050 = '#FFF8F0',
   Orange100 = '#FFE6C7',
@@ -272,12 +274,51 @@ const palette: PaletteOptions = {
       600: RawColor.Blue600,
       700: RawColor.Blue700,
       800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue800,
     },
   },
   secondary: {
-    light: '#0C3D99',
-    main: '#1A2974',
-    dark: '#161C4F',
+    light: RawColor.Blue800,
+    main: RawColor.Blue900,
+    dark: RawColor.Blue950,
+    hover: RawColor.Blue800,
+    active: lighten(RawColor.Blue800, action.activatedOpacity),
+    contrastText: RawColor.White,
+
+    lowEmphasis: {
+      light: RawColor.Blue050,
+      main: RawColor.Blue100,
+      dark: RawColor.Blue300,
+      contrastText: RawColor.Blue800,
+      hover: alpha(RawColor.Blue800, action.hoverOpacity),
+      active: alpha(RawColor.Blue800, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Blue700,
+      main: RawColor.Blue800,
+      dark: RawColor.Blue950,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      50: RawColor.Blue050,
+      100: RawColor.Blue100,
+      200: RawColor.Blue200,
+      300: RawColor.Blue300,
+      400: RawColor.Blue400,
+      500: RawColor.Blue500,
+      600: RawColor.Blue600,
+      700: RawColor.Blue700,
+      800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue950,
+    },
   },
   default: {
     light: RawColor.Grey400,

--- a/packages/themes/src/meteor/theme/dark.ts
+++ b/packages/themes/src/meteor/theme/dark.ts
@@ -233,6 +233,41 @@ const palette: PaletteOptions = {
     light: RawColor.Orange800,
     main: RawColor.Orange600,
     dark: RawColor.Orange400,
+    hover: RawColor.Orange400,
+    active: RawColor.Orange500,
+    contrastText: RawColor.Orange900,
+
+    lowEmphasis: {
+      light: RawColor.Orange800,
+      main: RawColor.Orange700,
+      dark: RawColor.Orange600,
+      contrastText: RawColor.Orange200,
+      hover: alpha(RawColor.Orange200, action.hoverOpacity),
+      active: alpha(RawColor.Orange200, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Orange500,
+      main: RawColor.Orange300,
+      dark: RawColor.Orange100,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      100: RawColor.Orange100,
+      200: RawColor.Orange200,
+      300: RawColor.Orange300,
+      400: RawColor.Orange400,
+      500: RawColor.Orange500,
+      600: RawColor.Orange600,
+      700: RawColor.Orange700,
+      800: RawColor.Orange800,
+      900: RawColor.Orange900,
+    },
   },
   default: {
     light: RawColor.Grey400,

--- a/packages/themes/src/meteor/theme/dark.ts
+++ b/packages/themes/src/meteor/theme/dark.ts
@@ -29,16 +29,15 @@ export enum RawColor {
   Grey800 = '#2B2E34',
   Grey900 = '#181A20',
 
-  Orange050 = '#591808',
-  Orange100 = '#913015',
-  Orange200 = '#AC3D1A',
-  Orange300 = '#D65024',
-  Orange400 = '#FA6B40',
-  Orange500 = '#FC9172',
-  Orange600 = '#FDAF9A',
-  Orange700 = '#FEC7B7',
-  Orange800 = '#FFDAD1',
-  Orange900 = '#FFF0EB',
+  Orange100 = '#FDECE6',
+  Orange200 = '#FAD9CC',
+  Orange300 = '#F6B399',
+  Orange400 = '#F18E66',
+  Orange500 = '#ED6833',
+  Orange600 = '#E84200',
+  Orange700 = '#BA3500',
+  Orange800 = '#8B2800',
+  Orange900 = '#5D1A00',
 
   Red100 = '#FFFFFF',
   Red200 = '#FFD6DD',
@@ -233,14 +232,14 @@ const palette: PaletteOptions = {
     light: RawColor.Orange800,
     main: RawColor.Orange600,
     dark: RawColor.Orange400,
-    hover: RawColor.Orange400,
-    active: RawColor.Orange500,
-    contrastText: RawColor.Orange900,
+    hover: RawColor.Orange700,
+    active: RawColor.Orange800,
+    contrastText: RawColor.White,
 
     lowEmphasis: {
-      light: RawColor.Orange800,
-      main: RawColor.Orange700,
-      dark: RawColor.Orange600,
+      light: RawColor.Orange900,
+      main: RawColor.Orange800,
+      dark: RawColor.Orange700,
       contrastText: RawColor.Orange200,
       hover: alpha(RawColor.Orange200, action.hoverOpacity),
       active: alpha(RawColor.Orange200, action.activatedOpacity),
@@ -248,8 +247,8 @@ const palette: PaletteOptions = {
 
     border: {
       light: RawColor.Orange500,
-      main: RawColor.Orange300,
-      dark: RawColor.Orange100,
+      main: RawColor.Orange400,
+      dark: RawColor.Orange300,
     },
 
     focusRing: {

--- a/packages/themes/src/meteor/theme/light.ts
+++ b/packages/themes/src/meteor/theme/light.ts
@@ -235,6 +235,40 @@ const palette: PaletteOptions = {
     main: RawColor.Orange600,
     dark: RawColor.Orange800,
     contrastText: RawColor.White,
+    hover: RawColor.Orange700,
+    active: RawColor.Orange800,
+
+    lowEmphasis: {
+      light: RawColor.Orange200,
+      main: RawColor.Orange300,
+      dark: RawColor.Orange400,
+      contrastText: RawColor.Orange600,
+      hover: RawColor.Orange200,
+      active: RawColor.Orange300,
+    },
+
+    border: {
+      light: RawColor.Orange400,
+      main: RawColor.Orange700,
+      dark: RawColor.Orange900,
+    },
+
+    focusRing: {
+      inner: RawColor.Blue800,
+      outer: RawColor.Blue400,
+    },
+
+    shades: {
+      100: RawColor.Orange100,
+      200: RawColor.Orange200,
+      300: RawColor.Orange300,
+      400: RawColor.Orange400,
+      500: RawColor.Orange500,
+      600: RawColor.Orange600,
+      700: RawColor.Orange700,
+      800: RawColor.Orange800,
+      900: RawColor.Orange900,
+    },
   },
   default: {
     light: RawColor.Grey600,

--- a/packages/themes/src/pcte/theme/dark.tsx
+++ b/packages/themes/src/pcte/theme/dark.tsx
@@ -4,7 +4,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme } from '@mui/material'
+import { alpha, createTheme, darken } from '@mui/material'
 
 import { baseTheme } from '@monorail/themes/legacy/theme/baseTheme'
 
@@ -289,8 +289,43 @@ const palette: PaletteOptions = {
   // Use as brand colors
   secondary: {
     light: RawColor.Purple300,
-    main: RawColor.Purple600,
-    dark: RawColor.Purple700,
+    main: RawColor.Purple500,
+    dark: RawColor.Purple600,
+    hover: darken(RawColor.Purple500, action.hoverOpacity),
+    active: darken(RawColor.Purple500, action.activatedOpacity),
+
+    lowEmphasis: {
+      light: RawColor.Purple900,
+      main: RawColor.Purple800,
+      dark: RawColor.Purple700,
+      contrastText: RawColor.Purple300,
+      hover: alpha(RawColor.Purple100, action.hoverOpacity),
+      active: alpha(RawColor.Purple100, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Purple800,
+      main: RawColor.Purple500,
+      dark: RawColor.Purple400,
+    },
+
+    focusRing: {
+      inner: RawColor.Purple800,
+      outer: RawColor.Purple400,
+    },
+
+    shades: {
+      50: RawColor.Purple050,
+      100: RawColor.Purple100,
+      200: RawColor.Purple200,
+      300: RawColor.Purple300,
+      400: RawColor.Purple400,
+      500: RawColor.Purple500,
+      600: RawColor.Purple600,
+      700: RawColor.Purple700,
+      800: RawColor.Purple800,
+      900: RawColor.Purple900,
+    },
   },
   default: {
     light: RawColor.Grey700,

--- a/packages/themes/src/pcte/theme/light.tsx
+++ b/packages/themes/src/pcte/theme/light.tsx
@@ -4,7 +4,7 @@ import type {
   ThemeOptions,
   TypeAction,
 } from '@mui/material'
-import { alpha, createTheme } from '@mui/material'
+import { alpha, createTheme, darken } from '@mui/material'
 
 import { baseTheme } from '@monorail/themes/legacy/theme/baseTheme'
 
@@ -43,6 +43,8 @@ export enum RawColor {
   Blue600 = '#1465FF',
   Blue700 = '#1050CB',
   Blue800 = '#0C3D9C',
+  Blue900 = '#1A2974',
+  Blue950 = '#161C4F',
 
   Purple050 = '#F5E2FF',
   Purple100 = '#D6B7E7',
@@ -283,6 +285,8 @@ const palette: PaletteOptions = {
       600: RawColor.Blue600,
       700: RawColor.Blue700,
       800: RawColor.Blue800,
+      900: RawColor.Blue900,
+      950: RawColor.Blue800,
     },
   },
   // Use as brand colors
@@ -290,6 +294,41 @@ const palette: PaletteOptions = {
     light: RawColor.Purple300,
     main: RawColor.Purple600,
     dark: RawColor.Purple700,
+    hover: darken(RawColor.Purple600, action.hoverOpacity),
+    active: darken(RawColor.Purple600, action.activatedOpacity),
+
+    lowEmphasis: {
+      light: RawColor.Purple050,
+      main: RawColor.Purple100,
+      dark: RawColor.Purple300,
+      contrastText: RawColor.Purple600,
+      hover: alpha(RawColor.Purple400, action.hoverOpacity),
+      active: alpha(RawColor.Purple400, action.activatedOpacity),
+    },
+
+    border: {
+      light: RawColor.Purple400,
+      main: RawColor.Purple600,
+      dark: RawColor.Purple800,
+    },
+
+    focusRing: {
+      inner: RawColor.Purple800,
+      outer: RawColor.Purple400,
+    },
+
+    shades: {
+      50: RawColor.Purple050,
+      100: RawColor.Purple100,
+      200: RawColor.Purple200,
+      300: RawColor.Purple300,
+      400: RawColor.Purple400,
+      500: RawColor.Purple500,
+      600: RawColor.Purple600,
+      700: RawColor.Purple700,
+      800: RawColor.Purple800,
+      900: RawColor.Purple900,
+    },
   },
   default: {
     light: RawColor.Grey400,

--- a/packages/types/src/themeAugmentation.ts
+++ b/packages/types/src/themeAugmentation.ts
@@ -23,6 +23,7 @@ export type ColorShades = {
   700: string
   800?: string
   900?: string
+  950?: string
   A100?: string
   A200?: string
   A400?: string


### PR DESCRIPTION
🎫 https://resolvn.atlassian.net/browse/UXE-80

- Added `secondary.lowEmphasis`, `.border`, `.focusRing`, `hover`, and `active` color tokens to all themes.
- Re-enabled the `<IconButton color="secondary" />` variant.