### PR TITLE
[UXE-104] Add lineClamp prop to Link

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.105",
+  "version": "3.0.106",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/Link/Link.tsx
+++ b/packages/components/src/Link/Link.tsx
@@ -1,4 +1,14 @@
+import React from 'react'
+import type { LinkProps as MuiLinkProps } from '@mui/material'
 import { Link as MuiLink } from '@mui/material'
+
+import { combineSxProps, getLineClampStyles } from '@monorail/utils'
+
+import type { TypographyProps } from '../Typography.js'
+
+export interface LinkProps
+  extends MuiLinkProps,
+    Pick<TypographyProps, 'lineClamp'> {}
 
 /**
  *
@@ -13,6 +23,20 @@ import { Link as MuiLink } from '@mui/material'
  * - [Link API](https://mui.com/material-ui/api/link/)
  * - inherits [Typography API](https://mui.com/material-ui/api/typography/)
  */
-export const Link: typeof MuiLink = MuiLink
+export const Link = React.forwardRef(function Link(props, ref) {
+  const { lineClamp, sx: sxProp, ...other } = props
+  return (
+    <MuiLink
+      {...other}
+      ref={ref}
+      sx={combineSxProps(
+        {
+          ...(lineClamp !== undefined && getLineClampStyles(lineClamp)),
+        },
+        sxProp,
+      )}
+    />
+  )
+}) as (props: LinkProps) => JSX.Element
 
 export * from '@mui/material/Link'

--- a/packages/components/src/ListItemText/ListItemText.tsx
+++ b/packages/components/src/ListItemText/ListItemText.tsx
@@ -1,12 +1,9 @@
 /* eslint-disable @typescript-eslint/strict-boolean-expressions */
 import React from 'react'
-import type {
-  CSSObject,
-  ListItemTextProps as MuiListItemTextProps,
-} from '@mui/material'
+import type { ListItemTextProps as MuiListItemTextProps } from '@mui/material'
 import { ListItemText as MuiListItemText } from '@mui/material'
 
-import { combineSxProps } from '@monorail/utils'
+import { combineSxProps, getLineClampStyles } from '@monorail/utils'
 
 import type { TypographyProps } from '../Typography.js'
 
@@ -106,21 +103,3 @@ export const ListItemText = React.forwardRef(function ListItemText(props, ref) {
 ) => JSX.Element
 
 export * from '@mui/material/ListItemText'
-
-function getLineClampStyles(lineClamp: number): CSSObject {
-  if (lineClamp === 1) {
-    return {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    }
-  } else {
-    return {
-      display: '-webkit-box',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      WebkitLineClamp: lineClamp,
-      WebkitBoxOrient: 'vertical',
-    }
-  }
-}

--- a/packages/components/src/Typography/Typography.tsx
+++ b/packages/components/src/Typography/Typography.tsx
@@ -1,12 +1,11 @@
 import type {
-  CSSObject,
   TypographyProps as MuiTypographyProps,
   TypographyTypeMap,
 } from '@mui/material'
 import { Typography as MuiTypography } from '@mui/material'
 import type { OverridableComponent } from '@mui/material/OverridableComponent'
 
-import { excludeProps, styled } from '@monorail/utils'
+import { excludeProps, getLineClampStyles, styled } from '@monorail/utils'
 
 declare module '@mui/material/Typography' {
   interface TypographyPropsVariantOverrides {
@@ -71,23 +70,5 @@ export const Typography = TypographyRoot as OverridableComponent<
 // @ts-expect-error
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 Typography.muiName = MuiTypography.muiName
-
-function getLineClampStyles(lineClamp: number): CSSObject {
-  if (lineClamp === 1) {
-    return {
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      whiteSpace: 'nowrap',
-    }
-  } else {
-    return {
-      display: '-webkit-box',
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      WebkitLineClamp: lineClamp,
-      WebkitBoxOrient: 'vertical',
-    }
-  }
-}
 
 export * from '@mui/material/Typography'

--- a/packages/storybook/src/Link/Link.stories.tsx
+++ b/packages/storybook/src/Link/Link.stories.tsx
@@ -34,6 +34,11 @@ export const Basic = story<LinkProps>(
       <Link href="#" variant="body2">
         {'variant="body2"'}
       </Link>
+      <Stack direction="column" maxWidth={100}>
+        <Link lineClamp={1} href="#">
+          Truncated link
+        </Link>
+      </Stack>
     </Stack>
   ),
   {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.105",
+  "version": "3.0.106",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.105",
+  "version": "3.0.106",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.105",
+  "version": "3.0.106",
   "license": "Apache-2.0",
   "exports": {
     "./*": {

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -1,4 +1,5 @@
 export * from './helpers/fileSizeFormatters.js'
+export * from './helpers/getLineClampStyles.js'
 export * from './helpers/math.js'
 
 export {

--- a/packages/utils/src/helpers/getLineClampStyles.ts
+++ b/packages/utils/src/helpers/getLineClampStyles.ts
@@ -1,0 +1,19 @@
+import type { CSSObject } from '@mui/material'
+
+export function getLineClampStyles(lineClamp: number): CSSObject {
+  if (lineClamp === 1) {
+    return {
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }
+  } else {
+    return {
+      display: '-webkit-box',
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      WebkitLineClamp: lineClamp,
+      WebkitBoxOrient: 'vertical',
+    }
+  }
+}

--- a/packages/utils/src/hooks.ts
+++ b/packages/utils/src/hooks.ts
@@ -14,6 +14,7 @@ export {
   useForkRef,
   useColorScheme,
   useEventCallback,
+  useMediaQuery,
 } from '@mui/material'
 
 export {


### PR DESCRIPTION
🎫 https://resolvn.atlassian.net/browse/UXE-104

`@monorail/components`
- Adds `lineClamp` prop support for the Link component

`@monorail/utils`
- Exports `getLineClampStyles` as a reusable helper
- Exports `useMediaQuery` from MUI