### PR TITLE
[UXE-124] ListSubheader action buttons

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/storybook/src/ListSubheader/ListSubheader.stories.tsx
+++ b/packages/storybook/src/ListSubheader/ListSubheader.stories.tsx
@@ -2,7 +2,13 @@
 import React from 'react'
 
 import type { ListSubheaderProps } from '@monorail/components'
-import { ListSubheader } from '@monorail/components'
+import {
+  IconButton,
+  ListSubheader,
+  Stack,
+  Typography,
+} from '@monorail/components'
+import { Add, Close } from '@monorail/components/icons'
 
 import { story } from '../helpers/storybook.js'
 
@@ -21,3 +27,45 @@ const Template = story<ListSubheaderProps>(
 )
 
 export const Default = story(Template)
+
+/**
+ * Additional elements are pushed to the right by default.
+ */
+export const WithActionButtons = story<ListSubheaderProps>(args => (
+  <ul>
+    <ListSubheader {...args} sx={{ maxWidth: 300 }}>
+      <Typography variant="inherit">List Subheader</Typography>
+      <IconButton onClick={() => {}} aria-hidden>
+        <Add />
+      </IconButton>
+    </ListSubheader>
+    <ListSubheader {...args} sx={{ maxWidth: 300 }}>
+      <Typography variant="inherit">List Subheader</Typography>
+      <Stack direction="row">
+        <IconButton onClick={() => {}} aria-hidden>
+          <Close />
+        </IconButton>
+        <IconButton onClick={() => {}} aria-hidden>
+          <Add />
+        </IconButton>
+      </Stack>
+    </ListSubheader>
+  </ul>
+))
+
+/**
+ * Wrap the subheader text in a Typography component to enable line-clamping and to keep other elements from being hidden.
+ */
+export const TextOverflow = story<ListSubheaderProps>(args => (
+  <ul>
+    <ListSubheader {...args} sx={{ maxWidth: 300 }}>
+      <Typography variant="inherit" lineClamp={2}>
+        A long subheader text will wrap and clamp when it reaches two lines of
+        text
+      </Typography>
+      <IconButton onClick={() => {}} aria-hidden>
+        <Add />
+      </IconButton>
+    </ListSubheader>
+  </ul>
+))

--- a/packages/storybook/src/ListSubheader/ListSubheader.stories.tsx
+++ b/packages/storybook/src/ListSubheader/ListSubheader.stories.tsx
@@ -2,13 +2,8 @@
 import React from 'react'
 
 import type { ListSubheaderProps } from '@monorail/components'
-import {
-  IconButton,
-  ListSubheader,
-  Stack,
-  Typography,
-} from '@monorail/components'
-import { Add, Close } from '@monorail/components/icons'
+import { IconButton, ListSubheader, Typography } from '@monorail/components'
+import { Add } from '@monorail/components/icons'
 
 import { story } from '../helpers/storybook.js'
 
@@ -31,24 +26,13 @@ export const Default = story(Template)
 /**
  * Additional elements are pushed to the right by default.
  */
-export const WithActionButtons = story<ListSubheaderProps>(args => (
+export const WithActionButton = story<ListSubheaderProps>(args => (
   <ul>
     <ListSubheader {...args} sx={{ maxWidth: 300 }}>
       <Typography variant="inherit">List Subheader</Typography>
       <IconButton onClick={() => {}} aria-hidden>
         <Add />
       </IconButton>
-    </ListSubheader>
-    <ListSubheader {...args} sx={{ maxWidth: 300 }}>
-      <Typography variant="inherit">List Subheader</Typography>
-      <Stack direction="row">
-        <IconButton onClick={() => {}} aria-hidden>
-          <Close />
-        </IconButton>
-        <IconButton onClick={() => {}} aria-hidden>
-          <Add />
-        </IconButton>
-      </Stack>
     </ListSubheader>
   </ul>
 ))

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/classic/components/ListSubheader/themeOverrides.ts
+++ b/packages/themes/src/classic/components/ListSubheader/themeOverrides.ts
@@ -7,6 +7,11 @@ export const MonorailListSubheaderOverrides: Components<Theme>['MuiListSubheader
       root: ({ theme }) => ({
         backgroundColor: 'transparent',
         ...theme.typography.listSubheader,
+        paddingLeft: theme.spacing(6),
+        paddingRight: theme.spacing(2),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
       }),
     },
   }

--- a/packages/themes/src/legacy/components/ListSubheader/themeOverrides.tsx
+++ b/packages/themes/src/legacy/components/ListSubheader/themeOverrides.tsx
@@ -7,8 +7,9 @@ export const MonorailListSubheaderOverrides: Components<Theme>['MuiListSubheader
       root: ({ theme }) => ({
         backgroundColor: 'transparent',
         ...theme.typography.listSubheader,
-        lineHeight: theme.spacing(6),
-        paddingLeft: theme.spacing(2),
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
       }),
     },
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.110",
+  "version": "3.0.111",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
🎫 https://resolvn.atlassian.net/browse/UXE-124

- Modified `ListSubheader` styles to push additional elements to the right by default.
- Added story: ListSubheader/With Action Buttons
- Added story: ListSubheader/Text Overflow 

![image](https://github.com/Simspace/monorail/assets/35754959/b6402bde-c7f8-41aa-867e-827fa2a25c82)

<img width="313" alt="image" src="https://github.com/Simspace/monorail/assets/35754959/2675d718-6da8-4d60-add4-38ad8b868ad2">

