### PR TITLE
fix(data-grid): server pagination

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.111",
+  "version": "3.0.112",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/DataGrid/components/DataGridFooter.tsx
+++ b/packages/components/src/DataGrid/components/DataGridFooter.tsx
@@ -135,14 +135,14 @@ export function DataGridPaginationFooter(props: DataGridFooterProps) {
     }
   }, [clientPageCount, pageSize, paginationMode, totalRowCount])
 
-  const onPageChangeHandler = React.useCallback(
+  const handlePageChange = React.useCallback(
     (_event: React.ChangeEvent<unknown>, page: number) => {
       apiRef.current.setPage(page - 1)
     },
     [apiRef],
   )
 
-  const onPageSizeChangeHandler = React.useCallback(
+  const handlePageSizeChange = React.useCallback(
     (event: SelectChangeEvent<number>) => {
       apiRef.current.setPageSize(Number(event.target.value))
     },
@@ -189,7 +189,7 @@ export function DataGridPaginationFooter(props: DataGridFooterProps) {
       <Pagination
         count={pageCount}
         page={page + 1}
-        onChange={onPageChangeHandler}
+        onChange={handlePageChange}
         siblingCount={1}
         renderItem={renderPaginationItem}
         {...paginationProps}
@@ -225,11 +225,13 @@ export function DataGridPaginationFooter(props: DataGridFooterProps) {
                   minWidth: theme.spacing(24),
                 })}
                 value={gridPageSizeSelector(apiRef)}
-                onChange={onPageSizeChangeHandler}
+                onChange={handlePageSizeChange}
               >
-                <MenuItem value={20}>20</MenuItem>
-                <MenuItem value={50}>50</MenuItem>
-                <MenuItem value={100}>100</MenuItem>
+                {rootProps.pageSizeOptions.map(pageSize => (
+                  <MenuItem value={pageSize} key={pageSize}>
+                    {pageSize}
+                  </MenuItem>
+                ))}
               </Select>
             }
             slotProps={{

--- a/packages/components/src/DataGrid/hooks/useDataGridProps.ts
+++ b/packages/components/src/DataGrid/hooks/useDataGridProps.ts
@@ -139,6 +139,8 @@ export function useDataGridProps<R extends GridValidRowModel>(
     [initProps],
   )
 
+  const pageSizeOptions = initProps.pageSizeOptions ?? [20, 50, 100]
+
   return useDataGridPremiumProps({
     ...initProps,
     disableColumnFilter: true,
@@ -151,5 +153,6 @@ export function useDataGridProps<R extends GridValidRowModel>(
     viewStyle: initProps.viewStyle ?? 'table',
     filter: initProps.filter ?? 'column',
     getRowClassName,
+    pageSizeOptions,
   })
 }

--- a/packages/storybook/src/DataGrid/DataGridPagination.stories.tsx
+++ b/packages/storybook/src/DataGrid/DataGridPagination.stories.tsx
@@ -168,6 +168,7 @@ AutoPaginationGrid.parameters = {
  */
 function loadServerRows(
   page: number,
+  pageSize: number,
   filter: string,
   data: GridDemoData,
 ): Promise<{
@@ -187,7 +188,10 @@ function loadServerRows(
           .includes(filter.toLocaleLowerCase()),
       )
 
-      const paginatedData = filteredData.slice(page * 20, (page + 1) * 20)
+      const paginatedData = filteredData.slice(
+        page * pageSize,
+        (page + 1) * pageSize,
+      )
 
       resolve({
         page,
@@ -205,6 +209,7 @@ export const ServerPaginationGrid = story<DataGridProps>(args => {
     maxColumns: 6,
   })
   const [page, setPage] = React.useState(0)
+  const [pageSize, setPageSize] = React.useState(20)
   const [rowCount, setRowCount] = React.useState(0)
   const [rows, setRows] = React.useState<GridRowsProp>([])
   const [loading, setLoading] = React.useState<boolean>(false)
@@ -215,7 +220,7 @@ export const ServerPaginationGrid = story<DataGridProps>(args => {
 
     ;(async () => {
       setLoading(true)
-      const newRows = await loadServerRows(page, filter, data)
+      const newRows = await loadServerRows(page, pageSize, filter, data)
 
       if (!active) {
         return
@@ -230,7 +235,7 @@ export const ServerPaginationGrid = story<DataGridProps>(args => {
     return () => {
       active = false
     }
-  }, [page, data, filter])
+  }, [page, pageSize, data, filter])
 
   return (
     <div style={{ height: 800, width: '100%' }}>
@@ -239,11 +244,14 @@ export const ServerPaginationGrid = story<DataGridProps>(args => {
         rows={rows}
         columns={data.columns}
         pagination
-        paginationModel={{ pageSize: 20, page }}
+        paginationModel={{ pageSize, page }}
         pageSizeOptions={[20, 50, 100]}
         rowCount={rowCount}
         paginationMode="server"
-        onPaginationModelChange={({ page }) => setPage(page)}
+        onPaginationModelChange={({ page, pageSize }) => {
+          setPageSize(pageSize)
+          setPage(page)
+        }}
         slotProps={{
           toolbar: {
             slotProps: {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.111",
+  "version": "3.0.112",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.111",
+  "version": "3.0.112",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.111",
+  "version": "3.0.112",
   "license": "Apache-2.0",
   "exports": {
     "./*": {

--- a/packages/utils/src/hooks.ts
+++ b/packages/utils/src/hooks.ts
@@ -3,6 +3,7 @@ export * from './hooks/useColorProp.js'
 export * from './hooks/useDebouncedCallback.js'
 export * from './hooks/useDidUpdate.js'
 export * from './hooks/useForceUpdate.js'
+export * from './hooks/useLatch.js'
 export * from './hooks/usePrevious.js'
 export * from './hooks/useRequestAnimationFrame.js'
 // codegen:end

--- a/packages/utils/src/hooks/useLatch.ts
+++ b/packages/utils/src/hooks/useLatch.ts
@@ -1,0 +1,20 @@
+import React from 'react'
+
+/**
+ * Prevents the changing of a value until a boolean condition is true.
+ *
+ * @param latch the boolean condition that must be true before the value can change
+ * @param value the changing value
+ * @returns the value that will change when the boolean condition is true
+ */
+export function useLatch<A>(latch: boolean, value: A): A {
+  const [state, set] = React.useState(value)
+
+  React.useEffect(() => {
+    if (latch) {
+      set(value)
+    }
+  }, [latch, value])
+
+  return state
+}


### PR DESCRIPTION
I used DataGrid to implement a server-paginated table and noticed that it wasn't working. It only showed one page, even though I was passing in the `rowCount` prop, which provides the total number of rows that the server could send. Upon further investigation, I noticed it was because of an issue in the implementation of our pagination footer in Monorail.

This PR fixes the implementation, as well as corrects some inconsistencies in the display of the row range in the right corner of the pagination footer.