### PR TITLE
[UXE-44] Add `text.placeholder` color token

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.113",
+  "version": "3.0.114",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/storybook/src/theme/palette/Foundation.stories.tsx
+++ b/packages/storybook/src/theme/palette/Foundation.stories.tsx
@@ -64,6 +64,12 @@ export const Foundation = () => {
       colorValue: theme.palette.text.disabled,
       figmaStyle: 'text/disabled',
     },
+    {
+      token: '.placeholder',
+      description: '',
+      colorValue: theme.palette.text.placeholder,
+      figmaStyle: 'text/placeholder',
+    },
   ]
 
   const backgroundColors = [

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.113",
+  "version": "3.0.114",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/classic/components/Autocomplete/themeOverrides.tsx
+++ b/packages/themes/src/classic/components/Autocomplete/themeOverrides.tsx
@@ -53,10 +53,6 @@ export const MonorailAutocompleteOverrides: Components<Theme>['MuiAutocomplete']
           },
         },
       }),
-      endAdornment: ({ ownerState: { size = 'medium' } }) => ({
-        ...(size !== 'small' && {
-          top: 'calc(50% - 20px)',
-        }),
-      }),
+      endAdornment: { top: 'calc(50% - 20px)' },
     },
   }

--- a/packages/themes/src/classic/components/InputBase/themeOverrides.ts
+++ b/packages/themes/src/classic/components/InputBase/themeOverrides.ts
@@ -17,6 +17,12 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
         ...theme.typography.inputText,
       }
     },
+    input: ({ theme }) => ({
+      '&::placeholder': {
+        color: theme.palette.text.placeholder,
+        opacity: 1,
+      },
+    }),
     error: ({ theme }) => ({
       [`&.${inputBaseClasses.focused}`]: {
         boxShadow: `0 0 0 3px ${theme.palette.error.focusRing.outer}`,

--- a/packages/themes/src/classic/theme/dark.ts
+++ b/packages/themes/src/classic/theme/dark.ts
@@ -522,6 +522,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey400,
     disabled: RawColor.Grey600,
     link: RawColor.Blue300,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/themes/src/classic/theme/light.ts
+++ b/packages/themes/src/classic/theme/light.ts
@@ -521,6 +521,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey700,
     disabled: RawColor.Grey400,
     link: RawColor.Blue600,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/themes/src/legacy/components/InputBase/themeOverrides.ts
+++ b/packages/themes/src/legacy/components/InputBase/themeOverrides.ts
@@ -17,6 +17,12 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
         ...theme.typography.inputText,
       }
     },
+    input: ({ theme }) => ({
+      '&::placeholder': {
+        color: theme.palette.text.placeholder,
+        opacity: 1,
+      },
+    }),
     sizeSmall: ({ theme }) => ({
       minHeight: theme.spacing(6),
     }),

--- a/packages/themes/src/legacy/theme/dark.ts
+++ b/packages/themes/src/legacy/theme/dark.ts
@@ -522,6 +522,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey400,
     disabled: RawColor.Grey600,
     link: RawColor.Blue300,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/themes/src/legacy/theme/light.ts
+++ b/packages/themes/src/legacy/theme/light.ts
@@ -521,6 +521,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey700,
     disabled: RawColor.Grey400,
     link: RawColor.Blue600,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
+++ b/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
@@ -48,6 +48,7 @@ export const MonorailAutocompleteOverrides: Components<Theme>['MuiAutocomplete']
           padding: multiple === true ? '2px 9px' : '0 12px',
           [`& .${autocompleteClasses.input}`]: {
             padding: 0,
+            ...(multiple === true && { paddingLeft: 3 }),
           },
           [`&.${inputBaseClasses.sizeSmall}`]: {
             padding: theme.spacing(1.25, 3),
@@ -72,11 +73,7 @@ export const MonorailAutocompleteOverrides: Components<Theme>['MuiAutocomplete']
             { paddingRight: theme.spacing(21.25) },
         }),
       }),
-      endAdornment: ({ ownerState: { size = 'medium' } }) => ({
-        ...(size === 'large' && {
-          top: 'calc(50% - 20px)',
-        }),
-      }),
+      endAdornment: { top: 'calc(50% - 17px)' },
       inputRoot: ({ ownerState: { size = 'medium' } }) => ({
         padding: 0,
         minHeight: 40,

--- a/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
@@ -23,6 +23,12 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
         }),
       }
     },
+    input: ({ theme }) => ({
+      '&::placeholder': {
+        color: theme.palette.text.placeholder,
+        opacity: 1,
+      },
+    }),
     error: ({ theme }) => ({
       [`&.${inputBaseClasses.focused}`]: {
         boxShadow: `0 0 0 3px ${theme.palette.error.focusRing.outer}`,

--- a/packages/themes/src/meteor/theme/dark.ts
+++ b/packages/themes/src/meteor/theme/dark.ts
@@ -473,6 +473,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey300,
     disabled: RawColor.Grey500,
     link: RawColor.Blue300,
+    placeholder: RawColor.Grey600,
   },
   grey: {
     100: RawColor.Grey100,

--- a/packages/themes/src/meteor/theme/light.ts
+++ b/packages/themes/src/meteor/theme/light.ts
@@ -471,6 +471,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey600,
     disabled: RawColor.Grey500,
     link: RawColor.Blue700,
+    placeholder: RawColor.Grey400,
   },
   grey: {
     100: RawColor.Grey100,

--- a/packages/themes/src/pcte/theme/dark.tsx
+++ b/packages/themes/src/pcte/theme/dark.tsx
@@ -528,6 +528,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey400,
     disabled: RawColor.Grey600,
     link: RawColor.Blue300,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/themes/src/pcte/theme/light.tsx
+++ b/packages/themes/src/pcte/theme/light.tsx
@@ -531,6 +531,7 @@ const palette: PaletteOptions = {
     secondary: RawColor.Grey700,
     disabled: RawColor.Grey400,
     link: RawColor.Blue600,
+    placeholder: RawColor.Grey500,
   },
   grey: {
     50: RawColor.Grey050,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.113",
+  "version": "3.0.114",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/types/src/themeAugmentation.ts
+++ b/packages/types/src/themeAugmentation.ts
@@ -256,6 +256,7 @@ declare module '@mui/material/styles/createPalette' {
 
   interface TypeText {
     link: string
+    placeholder: string
   }
 }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.113",
+  "version": "3.0.114",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
🎫 https://resolvn.atlassian.net/browse/UXE-44

Created new `text.placeholder` color token
- Added to all themes
- Added to Palette/Foundation story
- Applied to `InputBase` for all themes and changed opacity to `1`

Fixed visual bugs in `Autocomplete`
- `endAdornment` vertical alignment
- Placeholder text's alignment with `InputLabel` when `multiple={true}`
- Checked all sizes across all themes

BEFORE:
<img width="527" alt="image" src="https://github.com/Simspace/monorail/assets/35754959/60d20b68-0190-4e3e-9ff7-5e5c88eaab50">

AFTER:
<img width="523" alt="image" src="https://github.com/Simspace/monorail/assets/35754959/4d40fb77-4546-4815-a6f2-12726b9e286c">


