### PR TITLE
feat(datagrid): add getScrollHeight to apiRef

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.115",
+  "version": "3.0.116",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/DataGrid/hooks/useDataGridComponent.ts
+++ b/packages/components/src/DataGrid/hooks/useDataGridComponent.ts
@@ -8,6 +8,7 @@ import type {
 
 import { useDataGridGlobalSearch } from './useDataGridGlobalSearch.js'
 import { useDataGridViewStyle } from './useDataGridViewStyle.js'
+import { useGetScrollHeight } from './useGetScrollHeight.js'
 import { useGridRowReorder } from './useGridRowReorder.js'
 import { useInitializeGridSubState } from './useInitializeGridSubState.js'
 import { useSetRowIndex } from './useSetRowIndex.js'
@@ -35,5 +36,6 @@ export function useDataGridComponent(
   }))
   useDataGridViewStyle(apiRef, props)
   useDataGridGlobalSearch(apiRef, props)
+  useGetScrollHeight(apiRef)
   return apiRef
 }

--- a/packages/components/src/DataGrid/hooks/useGetScrollHeight.ts
+++ b/packages/components/src/DataGrid/hooks/useGetScrollHeight.ts
@@ -1,0 +1,19 @@
+import React from 'react'
+import { useGridApiMethod } from '@mui/x-data-grid'
+import type { GridPrivateApiPremium } from '@mui/x-data-grid-premium/models/gridApiPremium'
+
+export function useGetScrollHeight(
+  apiRef: React.MutableRefObject<GridPrivateApiPremium>,
+) {
+  const getScrollHeight = React.useCallback(() => {
+    return apiRef.current.virtualScrollerRef?.current?.scrollHeight ?? null
+  }, [apiRef])
+
+  useGridApiMethod(
+    apiRef,
+    {
+      getScrollHeight,
+    },
+    'public',
+  )
+}

--- a/packages/components/src/DataGrid/models/gridApi.ts
+++ b/packages/components/src/DataGrid/models/gridApi.ts
@@ -7,6 +7,11 @@ declare module '@mui/x-data-grid-premium/models/gridApiPremium' {
   interface GridApiPremium {
     setViewStyle: (viewStyle: DataGridViewStyle, external?: boolean) => void
     setGlobalSearchValue: (value: string) => void
+    /**
+     * Returns the scroll height of the virtual scroller. If the grid is not initialized,
+     * null will be returned
+     */
+    getScrollHeight: () => number | null
   }
 }
 

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.115",
+  "version": "3.0.116",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.115",
+  "version": "3.0.116",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.115",
+  "version": "3.0.116",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
Adds a function to apiRef that returns the scroll height of the virtual scroller.