### PR TITLE
fix(Search): prevent clear button from cutting off placeholder text

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.116",
+  "version": "3.0.117",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/Search/Search.tsx
+++ b/packages/components/src/Search/Search.tsx
@@ -11,6 +11,7 @@ import {
   useThemeProps,
 } from '@monorail/utils'
 
+import { buttonClasses } from '../Button.js'
 import { IconButton } from '../IconButton.js'
 import { InputAdornment } from '../InputAdornment.js'
 import { TextField } from '../TextField.js'
@@ -40,12 +41,19 @@ const SearchRoot = styled(TextField, {
   name: 'MonorailSearch',
   slot: 'Root',
   overridesResolver,
-})<SearchRootProps>({})
+})<SearchRootProps>({
+  isolation: 'isolate',
+})
 
 const ClearButton = styled(IconButton, {
   name: 'MonorailSearch',
   slot: 'ClearButton',
-})({})
+})({
+  [`&.${buttonClasses.focusVisible}`]: {
+    // For focus state only to prevent hover background color from overlapping the input's outline.
+    zIndex: 1,
+  },
+})
 
 /**
  * `Search` is a convenience wrapper for `TextField`.
@@ -147,7 +155,7 @@ export const Search = React.forwardRef(function Search(inProps, ref) {
             {...slotProps.clearButton}
             onClick={handleClear}
             sx={combineSxProps(
-              { mr: -2, visibility: isClearable ? 'visible' : 'hidden' },
+              { mr: -2, display: isClearable ? 'inline-flex' : 'none' },
               slotProps.clearButton?.sx,
             )}
           >

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.116",
+  "version": "3.0.117",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.116",
+  "version": "3.0.117",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.116",
+  "version": "3.0.117",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
Use `display` property instead of `visibility` to hide clear button.

### Before
![image](https://github.com/Simspace/monorail/assets/35754959/3f940935-9afe-4c40-aaa3-4c3e61c4268c)

### After
<img width="323" alt="image" src="https://github.com/Simspace/monorail/assets/35754959/8bdc15a1-898e-49e7-b770-cf16bf241f53">

