### PR TITLE
fix(DataGrid): expand striped row bgcolor

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.119",
+  "version": "3.0.120",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/storybook/src/DataGrid/DataGridVirtualization.stories.tsx
+++ b/packages/storybook/src/DataGrid/DataGridVirtualization.stories.tsx
@@ -64,7 +64,7 @@ const Template = story<DataGridProps>(args => {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid {...args} {...data} columnBuffer={2} />
+      <DataGrid {...args} {...data} columnBuffer={2} stripedRows />
     </div>
   )
 })

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.119",
+  "version": "3.0.120",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/classic/components/DataGrid/themeOverrides.tsx
+++ b/packages/themes/src/classic/components/DataGrid/themeOverrides.tsx
@@ -16,7 +16,7 @@ export const MonorailDataGridOverrides: Components<Theme>['MuiDataGrid'] = {
     },
     row: ({ theme }) => {
       return {
-        width: '100%',
+        minWidth: '100%',
         [`&.${dataGridClasses.grouped}`]: {
           backgroundColor: theme.palette.default.lowEmphasis.light,
         },

--- a/packages/themes/src/meteor/components/DataGrid/themeOverrides.tsx
+++ b/packages/themes/src/meteor/components/DataGrid/themeOverrides.tsx
@@ -16,7 +16,7 @@ export const MonorailDataGridOverrides: Components<Theme>['MuiDataGrid'] = {
     },
     row: ({ theme }) => {
       return {
-        width: '100%',
+        minWidth: '100%',
         [`&.${dataGridClasses.grouped}`]: {
           backgroundColor: theme.palette.background.default,
         },

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.119",
+  "version": "3.0.120",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.119",
+  "version": "3.0.120",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
🎫 https://resolvn.atlassian.net/browse/UXE-152

## After
![image](https://github.com/Simspace/monorail/assets/35754959/f3712147-e914-4f96-8377-fa86773f5c2b)

Trade-off: The background color still gets cut off when shrinking down the right end of `DataGrid`'s body (first image). This is the default MUI behavior and only happens when `DataGrid`'s body has a horizontal scrollbar. It expands again after column resize (second image).
![image](https://github.com/Simspace/monorail/assets/35754959/a9c82def-547a-4340-9a97-ddda049929d7)
![image](https://github.com/Simspace/monorail/assets/35754959/c87f3cb2-671a-4050-94b4-93baa367189e)

## Before
Striped rows get cut off if the content is wider than the container's width.
![image](https://github.com/Simspace/monorail/assets/35754959/65f46506-5b1f-4d44-9ec6-e61443365357)

![image](https://github.com/Simspace/monorail/assets/35754959/fa97f96c-b824-438b-8f9a-753572fe772f)
