### PR TITLE
[CFP-2116] - Fixed menu alignment

### DIFF
--- a/packages/themes/src/classic/components/Popover/themeOverrides.ts
+++ b/packages/themes/src/classic/components/Popover/themeOverrides.ts
@@ -2,9 +2,9 @@ import type { Components, Theme } from '@mui/material'
 
 export const MonorailPopoverOverrides: Components<Theme>['MuiPopover'] = {
   styleOverrides: {
-    root: ({ theme }) => {
+    paper: ({ theme }) => {
       return {
-        margin: theme.spacing(4, 0),
+        margin: theme.spacing(2, 0),
       }
     },
   },


### PR DESCRIPTION
# Summary

Margin was applied to the `root` component, be it the container div that takes the whole screen, when it should've been applied to the `paper` component which is the actual menu container.

# Testing

This change was tested with the [CFP-2116 Stacksim PR](https://github.com/Simspace/stack-optimization-web/pull/442). To do that you can:

1. run `yarn build-pack` on monorail
2. run `yarn link ~/absolute/path/to/monorail --all` from Stacksim 
3. (Optional) - if you run into dependency issues that cause linking error, like I did with clsx, you can temporarily match either one to avoid it