### PR TITLE
feat(Meteor): button theme updates

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.129",
+  "version": "3.0.130",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/Button/Button.tsx
+++ b/packages/components/src/Button/Button.tsx
@@ -15,7 +15,7 @@ declare module '@mui/material/Button' {
     warning: true
     error: true
     inherit: false
-    secondary: false
+    secondary: true
   }
 }
 

--- a/packages/storybook/src/Autocomplete/Autocomplete.stories.tsx
+++ b/packages/storybook/src/Autocomplete/Autocomplete.stories.tsx
@@ -17,6 +17,7 @@ import {
 } from '@monorail/components'
 import { useTheme } from '@monorail/utils'
 
+import { isMeteorTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 import type { Movie } from '../helpers/testData.js'
 import { countries, countryToFlag, movies } from '../helpers/testData.js'
@@ -274,7 +275,7 @@ export const Sizes = story(args => {
         )}
         {...args}
       />
-      {theme.name.includes('meteor') && (
+      {isMeteorTheme(theme.name) && (
         <>
           <Autocomplete
             id="size-large-outlined"

--- a/packages/storybook/src/Button/Button.stories.tsx
+++ b/packages/storybook/src/Button/Button.stories.tsx
@@ -17,15 +17,6 @@ import { story } from '../helpers/storybook.js'
 
 export default { title: 'Inputs/Button', component: Button }
 
-const Template = story<ButtonProps>(args => <Button {...args} />, {
-  args: { children: 'It Worked!' },
-  muiName: 'MuiButton',
-})
-
-export const Default = story(Template, {
-  args: { children: 'Button', variant: 'contained' },
-})
-
 const colors = [
   'primary',
   'secondary',
@@ -36,6 +27,31 @@ const colors = [
 ] as const
 const variants = ['contained', 'outlined', 'text'] as const
 const sizes = ['small', 'medium', 'large'] as const
+
+const argTypes = {
+  variant: {
+    options: variants,
+    control: {
+      type: 'radio',
+    },
+  },
+  color: {
+    options: colors,
+    control: {
+      type: 'radio',
+    },
+  },
+}
+
+const Template = story<ButtonProps>(args => <Button {...args} />, {
+  args: { children: 'It Worked!' },
+  argTypes,
+  muiName: 'MuiButton',
+})
+
+export const Default = story(Template, {
+  args: { children: 'Button', variant: 'contained' },
+})
 
 const buttons = variants.map(variant => (
   <Box mb={10} key={variant}>

--- a/packages/storybook/src/Button/Button.stories.tsx
+++ b/packages/storybook/src/Button/Button.stories.tsx
@@ -26,8 +26,14 @@ export const Default = story(Template, {
   args: { children: 'Button', variant: 'contained' },
 })
 
-// TODO: Add tertiary color
-const colors = ['primary', 'success', 'error', 'warning', 'info'] as const
+const colors = [
+  'primary',
+  'secondary',
+  'success',
+  'error',
+  'warning',
+  'info',
+] as const
 const variants = ['contained', 'outlined', 'text'] as const
 const sizes = ['small', 'medium', 'large'] as const
 

--- a/packages/storybook/src/Button/Button.stories.tsx
+++ b/packages/storybook/src/Button/Button.stories.tsx
@@ -12,7 +12,9 @@ import {
   Stack,
   Typography,
 } from '@monorail/components'
+import { useTheme } from '@monorail/utils'
 
+import { isMeteorTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 
 export default { title: 'Inputs/Button', component: Button }
@@ -58,110 +60,130 @@ export const Default = story(Template, {
   args: { children: 'Button', variant: 'contained' },
 })
 
-const buttons = variants.map(variant => (
-  <Box mb={10} key={variant}>
-    <Typography variant="h1">{capitalize(variant)}</Typography>
-    {sizes.map(size => (
-      <React.Fragment key={size}>
-        <Typography variant="subtitle1" my={2}>
-          {capitalize(size)}
-        </Typography>
-        <Stack direction="row" spacing={2} my={2}>
-          {colors.map(color => (
-            <Button
-              key={`${variant}-${size}-${color}`}
-              variant={variant}
-              color={color}
-              size={size}
-            >
-              {color}
-            </Button>
-          ))}
-        </Stack>
-      </React.Fragment>
-    ))}
-    <Typography variant="subtitle1" my={2}>
-      Disabled
-    </Typography>
-    <Stack direction="row" spacing={2} my={2}>
-      {colors.map(color => (
-        <Button
-          disabled
-          variant={variant}
-          color={color}
-          size="medium"
-          key={`${variant}-${color}-disabled`}
-        >
-          Disabled
-        </Button>
-      ))}
-    </Stack>
-    <Typography variant="subtitle1" my={2}>
-      Inverted
-    </Typography>
-    <Typography>
-      Used when placing buttons on top of colored containers to create contrast.
-      Inverted text and inverted outlined Buttons inherit the text color of the
-      containing element. See the Alert/Actions story for examples.
-    </Typography>
-    <Stack
-      direction="row"
-      spacing={2}
-      my={2}
-      sx={{
-        p: 2,
-        bgcolor: 'default.light',
-      }}
-    >
-      {colors.map(color => (
-        <Button
-          variant={variant}
-          color={color}
-          size="medium"
-          key={`${variant}-${color}-inverted`}
-          inverted
-        >
-          {color}
-        </Button>
-      ))}
-    </Stack>
-  </Box>
-))
-
 /**
  * Use `variant` to set the display style and `color` to set the coloring
  */
-export const VariantsAndColors = story<ButtonProps>(() => <>{buttons}</>, {
-  parameters: {
-    a11y: {
-      /**
-       * Our orange buttons failed the WCAG 2.0 contrast test.
-       * It does pass APCA (WCAG 3), which is what we used for our Monorail3 color palette.
-       * Unfortunately, APCA isn't supported yet in axe's config options, but it something we should track.
-       * https://github.com/dequelabs/axe-core/issues/3325
-       * GS 6/13/22
-       */
-      disable: true,
+export const VariantsAndColors = story<ButtonProps>(
+  args => {
+    const theme = useTheme()
+    return (
+      <>
+        {variants.map(variant => (
+          <Box mb={10} key={variant}>
+            <Typography variant="h1">{capitalize(variant)}</Typography>
+            <Stack direction="row" spacing={2} my={2}>
+              {colors.map(color => (
+                <Button
+                  key={`${variant}-${color}`}
+                  variant={variant}
+                  color={color}
+                  size={args.size}
+                  disabled={args.disabled}
+                >
+                  {color}
+                </Button>
+              ))}
+            </Stack>
+            <Typography variant="subtitle1" mt={4} mb={2}>
+              Inverted
+            </Typography>
+            {isMeteorTheme(theme.name) ? (
+              <Typography>
+                Inverted variants are not supported in the Meteor theme.
+              </Typography>
+            ) : (
+              <>
+                <Typography>
+                  Used when placing buttons on top of colored containers to
+                  create contrast. Inverted text and inverted outlined Buttons
+                  inherit the text color of the containing element. See the
+                  Alert/Actions story for examples.
+                </Typography>
+                <Stack
+                  direction="row"
+                  spacing={2}
+                  my={2}
+                  sx={{
+                    p: 2,
+                    bgcolor: 'default.light',
+                  }}
+                >
+                  {colors.map(color => (
+                    <Button
+                      variant={variant}
+                      color={color}
+                      size="medium"
+                      key={`${variant}-${color}-inverted`}
+                      inverted
+                    >
+                      {color}
+                    </Button>
+                  ))}
+                </Stack>
+              </>
+            )}
+          </Box>
+        ))}
+      </>
+    )
+  },
+  {
+    parameters: {
+      a11y: {
+        /**
+         * Our orange buttons failed the WCAG 2.0 contrast test.
+         * It does pass APCA (WCAG 3), which is what we used for our Monorail3 color palette.
+         * Unfortunately, APCA isn't supported yet in axe's config options, but it something we should track.
+         * https://github.com/dequelabs/axe-core/issues/3325
+         * GS 6/13/22
+         */
+        disable: true,
+      },
+    },
+    args: {
+      disabled: false,
+    },
+    argTypes: {
+      disabled: {
+        control: {
+          type: 'boolean',
+        },
+      },
     },
   },
-})
+)
 
 /**
  * For larger or smaller buttons, use the `size` prop.
  */
-export const Sizes = story<ButtonProps>(() => (
-  <Stack direction="row" spacing={2} alignItems="center">
-    <Button variant="contained" size={'small'}>
-      Small
-    </Button>
-    <Button variant="contained" size={'medium'}>
-      Medium
-    </Button>
-    <Button variant="contained" size={'large'}>
-      Large
-    </Button>
-  </Stack>
-))
+export const Sizes = story<ButtonProps>(
+  args => (
+    <Stack direction="row" spacing={2} alignItems="center">
+      <Button variant="contained" size={'small'} color={args.color}>
+        Small
+      </Button>
+      <Button variant="contained" size={'medium'} color={args.color}>
+        Medium
+      </Button>
+      <Button variant="contained" size={'large'} color={args.color}>
+        Large
+      </Button>
+    </Stack>
+  ),
+  {
+    args: {
+      color: 'primary',
+    },
+    argTypes: {
+      color: {
+        options: colors,
+        control: {
+          type: 'radio',
+        },
+      },
+    },
+  },
+)
 
 /**
  * Sometimes you might want to have icons for certain buttons to enhance the UX of the application as we recognize logos more easily than plain text. For example, if you have a delete button you can label it with a dustbin icon.

--- a/packages/storybook/src/Button/Button.stories.tsx
+++ b/packages/storybook/src/Button/Button.stories.tsx
@@ -41,6 +41,11 @@ const argTypes = {
       type: 'radio',
     },
   },
+  disabled: {
+    control: {
+      type: 'boolean',
+    },
+  },
 }
 
 const Template = story<ButtonProps>(args => <Button {...args} />, {

--- a/packages/storybook/src/Chip/Chip.stories.tsx
+++ b/packages/storybook/src/Chip/Chip.stories.tsx
@@ -25,8 +25,8 @@ import {
 } from '@monorail/components/icons'
 import { useTheme } from '@monorail/utils'
 
-import { capitalizeFirstLetter } from '../helpers/helpers.js'
-import { isMeteorTheme, story } from '../helpers/storybook.js'
+import { capitalizeFirstLetter, isMeteorTheme } from '../helpers/helpers.js'
+import { story } from '../helpers/storybook.js'
 
 export default { title: 'Data Display/Chip', component: Chip }
 

--- a/packages/storybook/src/Chip/ChipShowcase.stories.tsx
+++ b/packages/storybook/src/Chip/ChipShowcase.stories.tsx
@@ -8,8 +8,8 @@ import type { ChipProps } from '@monorail/components'
 import { Avatar, Chip, Stack, Typography } from '@monorail/components'
 import { useTheme } from '@monorail/utils'
 
-import { capitalizeFirstLetter } from '../helpers/helpers.js'
-import { isMeteorTheme, story } from '../helpers/storybook.js'
+import { capitalizeFirstLetter, isMeteorTheme } from '../helpers/helpers.js'
+import { story } from '../helpers/storybook.js'
 
 export default { title: 'Data Display/Chip/Showcase', component: Chip }
 

--- a/packages/storybook/src/List/List.stories.tsx
+++ b/packages/storybook/src/List/List.stories.tsx
@@ -52,6 +52,7 @@ import {
 import { DragIndicator, WarningAmber } from '@monorail/components/icons'
 import { useTheme } from '@monorail/utils'
 
+import { isLegacyTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 
 declare module '@mui/styles/defaultTheme' {
@@ -755,7 +756,7 @@ export const GutterlessListItem = story<ListProps>(args => {
  */
 export const VirtualizedList = story<ListProps>(() => {
   const theme = useTheme()
-  const itemSize = theme.name.includes('legacy') ? 24 : 48
+  const itemSize = isLegacyTheme(theme.name) ? 24 : 48
   return (
     <Box
       sx={{

--- a/packages/storybook/src/Search/Search.stories.tsx
+++ b/packages/storybook/src/Search/Search.stories.tsx
@@ -14,6 +14,7 @@ import {
 } from '@monorail/components'
 import { useTheme } from '@monorail/utils'
 
+import { isMeteorTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 import { movies } from '../helpers/testData.js'
 
@@ -78,7 +79,7 @@ export const Sizes = story(
         <div>
           <Search label="Small" id="size-small" size="small" />
           <Search label="Medium" id="size-medium" />
-          {theme.name.includes('meteor') && (
+          {isMeteorTheme(theme.name) && (
             <Search label="Large" id="size-medium" size="large" />
           )}
         </div>

--- a/packages/storybook/src/Select/Select.stories.tsx
+++ b/packages/storybook/src/Select/Select.stories.tsx
@@ -15,6 +15,7 @@ import {
 } from '@monorail/components'
 import { useTheme } from '@monorail/utils'
 
+import { isMeteorTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 
 export default { title: 'Inputs/Select', component: Select }
@@ -103,7 +104,7 @@ export const Sizes = story<SelectProps<string>>(() => {
           <MenuItem value={30}>Thirty</MenuItem>
         </Select>
       </FormControl>
-      {theme.name.includes('meteor') && (
+      {isMeteorTheme(theme.name) && (
         <FormControl sx={{ m: 2, minWidth: 120 }}>
           <InputLabel id="demo-simple-select-large-label">Large</InputLabel>
           <Select

--- a/packages/storybook/src/TextField/TextField.stories.tsx
+++ b/packages/storybook/src/TextField/TextField.stories.tsx
@@ -16,6 +16,7 @@ import type { TextFieldProps } from '@monorail/components'
 import { MenuItem, TextField, useFormControl } from '@monorail/components'
 import { useTheme } from '@monorail/utils'
 
+import { isMeteorTheme } from '../helpers/helpers.js'
 import { story } from '../helpers/storybook.js'
 
 export default { title: 'Inputs/TextField', component: TextField }
@@ -427,7 +428,7 @@ export const Sizes = story(
             id="outlined-size-medium"
             defaultValue="Medium"
           />
-          {theme.name.includes('meteor') && (
+          {isMeteorTheme(theme.name) && (
             <TextField
               label="Size"
               id="outlined-size-large"

--- a/packages/storybook/src/helpers/helpers.ts
+++ b/packages/storybook/src/helpers/helpers.ts
@@ -1,4 +1,51 @@
 // Functions to be used in stories. Not intended to be used in Monorail.
+import { RawColor as ClassicDarkRawColors } from '@monorail/themes/classic/theme/dark'
+import { RawColor as ClassicLightRawColors } from '@monorail/themes/classic/theme/light'
+import { RawColor as LegacyDarkRawColors } from '@monorail/themes/legacy/theme/dark'
+import { RawColor as LegacyLightRawColors } from '@monorail/themes/legacy/theme/light'
+import { RawColor as MeteorDarkRawColors } from '@monorail/themes/meteor/theme/dark'
+import { RawColor as MeteorLightRawColors } from '@monorail/themes/meteor/theme/light'
+import { RawColor as MuiRawColors } from '@monorail/themes/mui/theme'
+import { RawColor as PcteDarkRawColors } from '@monorail/themes/pcte/theme/dark'
+import { RawColor as PcteLightRawColors } from '@monorail/themes/pcte/theme/light'
+
+import { ThemeName } from '../theme/palette/palette.types'
 
 export const capitalizeFirstLetter = (str: string) =>
   str.charAt(0).toUpperCase() + str.slice(1)
+
+export const isMeteorTheme = (themeName: ThemeName) =>
+  themeName === ThemeName.MeteorLight || themeName === ThemeName.MeteorDark
+
+export const isLegacyTheme = (themeName: ThemeName) =>
+  themeName === ThemeName.MeteorLight || themeName === ThemeName.MeteorDark
+
+/**
+ * Gets the `RawColor` object of a theme. Used for displaying the corresponding global token and value of an alias token.
+ * @param themeName theme.palette.name
+ * @returns RawColors object
+ */
+export const getRawColorObject = (themeName: ThemeName) => {
+  switch (themeName) {
+    case ThemeName.MeteorLight:
+      return MeteorLightRawColors
+    case ThemeName.MeteorDark:
+      return MeteorDarkRawColors
+    case ThemeName.ClassicLight:
+      return ClassicLightRawColors
+    case ThemeName.ClassicDark:
+      return ClassicDarkRawColors
+    case ThemeName.LegacyLight:
+      return LegacyLightRawColors
+    case ThemeName.LegacyDark:
+      return LegacyDarkRawColors
+    case ThemeName.MUILight:
+      return MuiRawColors
+    case ThemeName.MUIDark:
+      return MuiRawColors
+    case ThemeName.PCTELight:
+      return PcteLightRawColors
+    case ThemeName.PCTEDark:
+      return PcteDarkRawColors
+  }
+}

--- a/packages/storybook/src/helpers/storybook.ts
+++ b/packages/storybook/src/helpers/storybook.ts
@@ -14,15 +14,7 @@ import type {
 import type { AnnotatedStoryFn } from '@storybook/types'
 
 import { meteorLightTheme } from '@monorail/themes'
-import { RawColor as ClassicDarkRawColors } from '@monorail/themes/classic/theme/dark'
-import { RawColor as ClassicLightRawColors } from '@monorail/themes/classic/theme/light'
-import { RawColor as MeteorDarkRawColors } from '@monorail/themes/meteor/theme/dark'
-import { RawColor as MeteorLightRawColors } from '@monorail/themes/meteor/theme/light'
-import { RawColor as MuiRawColors } from '@monorail/themes/mui/theme'
-import { RawColor as PcteDarkRawColors } from '@monorail/themes/pcte/theme/dark'
-import { RawColor as PcteLightRawColors } from '@monorail/themes/pcte/theme/light'
 
-import { ThemeName } from '../theme/palette/palette.types'
 import { isNonEmptyString } from './typeGuards.js'
 
 type A11yParameter = {
@@ -238,32 +230,3 @@ export function story<T extends DefaultArgs>(
 
   return NewStory
 }
-
-/**
- * Gets the `RawColor` object of a theme. Used for displaying the corresponding global token and value of an alias token.
- * @param themeName theme.palette.name
- * @returns RawColors object
- */
-export const getRawColorObject = (themeName: ThemeName) => {
-  switch (themeName) {
-    case ThemeName.MeteorLight:
-      return MeteorLightRawColors
-    case ThemeName.MeteorDark:
-      return MeteorDarkRawColors
-    case ThemeName.ClassicLight:
-      return ClassicLightRawColors
-    case ThemeName.ClassicDark:
-      return ClassicDarkRawColors
-    case ThemeName.MUILight:
-      return MuiRawColors
-    case ThemeName.MUIDark:
-      return MuiRawColors
-    case ThemeName.PCTELight:
-      return PcteLightRawColors
-    case ThemeName.PCTEDark:
-      return PcteDarkRawColors
-  }
-}
-
-export const isMeteorTheme = (themeName: ThemeName) =>
-  themeName === ThemeName.MeteorLight || themeName === ThemeName.MeteorDark

--- a/packages/storybook/src/theme/palette/Action.stories.tsx
+++ b/packages/storybook/src/theme/palette/Action.stories.tsx
@@ -3,9 +3,9 @@ import { alpha, useTheme } from '@mui/material'
 
 import { Box, Typography } from '@monorail/components'
 
-import { getRawColorObject } from '../../helpers.js'
+import { getRawColorObject } from '../../helpers/helpers.js'
 import { ColorTokenTable } from './palette.components'
-import type { ColorTokenRowProps, ThemeName } from './palette.types'
+import type { ColorTokenRowProps } from './palette.types'
 
 export default {
   title: 'Theme/Palette/Action',
@@ -19,7 +19,7 @@ export const Action = () => {
   const theme = useTheme()
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 

--- a/packages/storybook/src/theme/palette/Foundation.stories.tsx
+++ b/packages/storybook/src/theme/palette/Foundation.stories.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Typography, useTheme } from '@mui/material'
 import Box from '@mui/material/Box'
 
-import { getRawColorObject } from '../../helpers.js'
+import { getRawColorObject } from '../../helpers/helpers.js'
 import { ColorTokenTable } from './palette.components'
-import type { ColorTokenRowProps, ThemeName } from './palette.types'
+import type { ColorTokenRowProps } from './palette.types'
 
 export default {
   title: 'Theme/Palette/Foundation',
@@ -18,7 +18,7 @@ export const Foundation = () => {
   const theme = useTheme()
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 

--- a/packages/storybook/src/theme/palette/Other.stories.tsx
+++ b/packages/storybook/src/theme/palette/Other.stories.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import { Typography, useTheme } from '@mui/material'
 import Box from '@mui/material/Box'
 
-import { getRawColorObject } from '../../helpers.js'
+import { getRawColorObject } from '../../helpers/helpers.js'
 import { ColorTokenTable } from './palette.components.js'
-import type { ColorTokenRowProps, ThemeName } from './palette.types.js'
+import type { ColorTokenRowProps } from './palette.types.js'
 
 export default {
   title: 'Theme/Palette/Other',
@@ -18,7 +18,7 @@ const TierColors = () => {
   const theme = useTheme()
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 
@@ -67,7 +67,7 @@ const ScoreColors = () => {
   const theme = useTheme()
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 
@@ -246,7 +246,7 @@ export const Other = () => {
   const theme = useTheme()
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 

--- a/packages/storybook/src/theme/palette/SemanticColors.stories.tsx
+++ b/packages/storybook/src/theme/palette/SemanticColors.stories.tsx
@@ -6,13 +6,9 @@ import Box from '@mui/material/Box'
 import type { TabPanelProps } from '@monorail/components'
 import { Tab, Tabs } from '@monorail/components'
 
-import { getRawColorObject } from '../../helpers.js'
+import { getRawColorObject } from '../../helpers/helpers.js'
 import { ColorTokenTable } from './palette.components'
-import type {
-  ColorTokenRowProps,
-  ColorTokenTableProps,
-  ThemeName,
-} from './palette.types'
+import type { ColorTokenRowProps, ColorTokenTableProps } from './palette.types'
 
 export default {
   title: 'Theme/Palette/Semantic Colors',
@@ -145,7 +141,7 @@ export const SemanticColors = () => {
   }
 
   const rawColorMapping = React.useMemo(
-    () => getRawColorObject(theme.name as ThemeName),
+    () => getRawColorObject(theme.name),
     [theme.name],
   )
 

--- a/packages/storybook/src/theme/palette/palette.types.ts
+++ b/packages/storybook/src/theme/palette/palette.types.ts
@@ -8,6 +8,8 @@ export enum ThemeName {
   MeteorDark = 'meteorDark',
   ClassicLight = 'classicLight',
   ClassicDark = 'classicDark',
+  LegacyLight = 'legacyLight',
+  LegacyDark = 'legacyDark',
   MUILight = 'muiLight',
   MUIDark = 'muiDark',
   PCTELight = 'pcteLight',

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.129",
+  "version": "3.0.130",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -86,24 +86,47 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
     }) => {
       return {
         color: theme.palette[color].contrastText,
-        backgroundColor:
-          color === 'primary'
-            ? theme.palette.primary.dark
-            : theme.palette[color].main,
+        backgroundColor: theme.palette[color].main,
         '&:hover': {
-          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
-          background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].main}`,
-          ...(color === 'secondary' && {
-            background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].light}`,
-          }),
+          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
+          background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].dark}`,
         },
         '&:active': {
-          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
-          background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].main}`,
-          ...(color === 'secondary' && {
-            background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].light}`,
-          }),
+          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
+          background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].dark}`,
         },
+        ...(color === 'primary' && {
+          backgroundColor: theme.palette[color].dark,
+          '&:hover': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].main}`,
+          },
+          '&:active': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].main}`,
+          },
+        }),
+        ...(color === 'secondary' && {
+          '&:hover': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].dark}`,
+          },
+          '&:active': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].dark}`,
+          },
+        }),
+        ...(color === 'warning' && {
+          backgroundColor: theme.palette[color].main,
+          '&:hover': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].main}`,
+          },
+          '&:active': {
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
+            background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].main}`,
+          },
+        }),
       }
     },
     outlined: ({

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -161,10 +161,10 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
       return {
         color: theme.palette[color].lowEmphasis.contrastText,
         '&:hover': {
-          backgroundColor: theme.palette[color].lowEmphasis.hover,
+          backgroundColor: theme.palette.action.hover,
         },
         '&:active': {
-          backgroundColor: theme.palette[color].lowEmphasis.active,
+          backgroundColor: theme.palette.action.active,
         },
       }
     },

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -40,7 +40,6 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
           }),
           ...(variant === 'outlined' && {
             color: theme.palette[color].lowEmphasis.contrastText,
-            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
           }),
           ...(variant === 'text' && {
             color: theme.palette[color].lowEmphasis.contrastText,
@@ -107,16 +106,25 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
       }
       theme: Theme
     }) => {
+      const colorPrimaryStyles: CSSInterpolation = {
+        color: theme.palette.text.primary,
+      }
+      const colorSecondaryStyles: CSSInterpolation = {
+        color: theme.palette.secondary.contrastText,
+      }
       const darkModeInteractionStates: CSSInterpolation = {
         '&:hover': {
           border: 'none',
-          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
-          backgroundColor: theme.palette.background.paper,
-          backgroundImage: `linear-gradient(${theme.palette[color].lowEmphasis.hover}, ${theme.palette[color].lowEmphasis.hover})`,
+          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
+          background: theme.palette[color].lowEmphasis.hover,
+          ...(color === 'secondary' && colorSecondaryStyles),
         },
         '&:active': {
-          backgroundColor: theme.palette.background.paper,
-          backgroundImage: `linear-gradient(${theme.palette[color].lowEmphasis.active}, ${theme.palette[color].lowEmphasis.active})`,
+          background: theme.palette[color].lowEmphasis.active,
+          ...(color === 'secondary' && {
+            ...colorSecondaryStyles,
+            boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
+          }),
         },
       }
       const lightModeInteractionStates: CSSInterpolation = {
@@ -135,10 +143,10 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
           : lightModeInteractionStates
 
       return {
-        backgroundColor: theme.palette.background.paper,
-        boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
+        backgroundColor: theme.palette[color].lowEmphasis.light,
         color: theme.palette[color].lowEmphasis.contrastText,
         ...outlinedButtonInteractionStates,
+        ...(color === 'primary' && colorPrimaryStyles),
       }
     },
     text: ({

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -5,7 +5,7 @@ import type {
   CSSInterpolation,
   Theme,
 } from '@mui/material'
-import { alpha, buttonClasses } from '@mui/material'
+import { buttonClasses } from '@mui/material'
 
 export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
   defaultProps: {
@@ -28,11 +28,14 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
         },
         [`&.${buttonClasses.disabled}`]: {
           border: 'none',
-          // I tried using the disabled prop, https://mui.com/api/button/#css
-          // but it wouldn't override the default styles
-          // This pattern seems to work better for .Mui-[state]
+          opacity: theme.palette.action.disabledOpacity,
+          // The `disabled` class key doesn't work, https://mui.com/api/button/#css
+          // This pattern seems to work better for .Mui-[state] overrides
           ...(variant === 'contained' && {
-            backgroundColor: theme.palette[color].main,
+            backgroundColor:
+              color === 'primary'
+                ? theme.palette[color].dark
+                : theme.palette[color].main,
             color: theme.palette[color].contrastText,
           }),
           ...(variant === 'outlined' && {
@@ -81,23 +84,17 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
     }) => {
       return {
         color: theme.palette[color].contrastText,
+        backgroundColor:
+          color === 'primary'
+            ? theme.palette[color].dark
+            : theme.palette[color].main,
         '&:hover': {
-          backgroundColor: theme.palette[color].hover,
+          background: theme.palette[color].hover,
+          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
         },
         '&:active': {
-          backgroundColor: theme.palette[color].active,
-        },
-        '&.MonorailButton-inverted': {
-          backgroundColor: theme.palette.background.paper,
-          color: theme.palette[color].lowEmphasis.contrastText,
-          // Making an exception to not use .hover and .active tokens because of this variant needs a special visual treatment.
-          // We can tokenize this pattern if it becomes more common. GS 9/9/22
-          '&:hover': {
-            backgroundColor: alpha(theme.palette.background.paper, 0.8),
-          },
-          '&:active': {
-            backgroundColor: alpha(theme.palette.background.paper, 0.5),
-          },
+          background: theme.palette[color].active,
+          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
         },
       }
     },
@@ -142,26 +139,6 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
         boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
         color: theme.palette[color].lowEmphasis.contrastText,
         ...outlinedButtonInteractionStates,
-        '&.MonorailButton-inverted': {
-          backgroundColor: 'transparent',
-          color: 'currentColor',
-          boxShadow: `inset 0 0 0 1px currentColor`,
-          '&:hover': {
-            border: 'none',
-            backgroundColor: alpha(
-              theme.palette.common.black,
-              theme.palette.action.hoverOpacity,
-            ),
-            boxShadow: `inset 0 0 0 1px currentColor`,
-          },
-          '&:active': {
-            backgroundColor: alpha(
-              theme.palette.common.black,
-              theme.palette.action.activatedOpacity,
-            ),
-            boxShadow: `inset 0 0 0 1px currentColor`,
-          },
-        },
       }
     },
     text: ({
@@ -180,22 +157,6 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
         },
         '&:active': {
           backgroundColor: theme.palette[color].lowEmphasis.active,
-        },
-        '&.MonorailButton-inverted': {
-          backgroundColor: 'transparent',
-          color: 'currentColor',
-          '&:hover': {
-            backgroundColor: alpha(
-              theme.palette.common.black,
-              theme.palette.action.hoverOpacity,
-            ),
-          },
-          '&:active': {
-            backgroundColor: alpha(
-              theme.palette.common.black,
-              theme.palette.action.activatedOpacity,
-            ),
-          },
         },
       }
     },

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -39,7 +39,10 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
             color: theme.palette[color].contrastText,
           }),
           ...(variant === 'outlined' && {
-            color: theme.palette[color].lowEmphasis.contrastText,
+            color:
+              color === 'primary'
+                ? theme.palette.text.primary
+                : theme.palette[color].lowEmphasis.contrastText,
           }),
           ...(variant === 'text' && {
             color: theme.palette[color].lowEmphasis.contrastText,
@@ -112,23 +115,15 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
       }
       theme: Theme
     }) => {
-      const colorPrimaryStyles: CSSInterpolation = {
-        color: theme.palette.text.primary,
-      }
-      const colorSecondaryStyles: CSSInterpolation = {
-        color: theme.palette.secondary.contrastText,
-      }
       const outlinedButtonInteractionStates: CSSInterpolation = {
         '&:hover': {
           border: 'none',
           boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
           background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].lowEmphasis.light}`,
-          ...(color === 'secondary' && colorSecondaryStyles),
         },
         '&:active': {
           background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].lowEmphasis.light}`,
           ...(color === 'secondary' && {
-            ...colorSecondaryStyles,
             boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
           }),
         },
@@ -138,7 +133,9 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
         backgroundColor: theme.palette[color].lowEmphasis.light,
         color: theme.palette[color].lowEmphasis.contrastText,
         ...outlinedButtonInteractionStates,
-        ...(color === 'primary' && colorPrimaryStyles),
+        ...(color === 'primary' && {
+          color: theme.palette.text.primary,
+        }),
       }
     },
     text: ({

--- a/packages/themes/src/meteor/components/Button/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Button/themeOverrides.ts
@@ -85,15 +85,21 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
         color: theme.palette[color].contrastText,
         backgroundColor:
           color === 'primary'
-            ? theme.palette[color].dark
+            ? theme.palette.primary.dark
             : theme.palette[color].main,
         '&:hover': {
-          background: theme.palette[color].hover,
           boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+          background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].main}`,
+          ...(color === 'secondary' && {
+            background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].light}`,
+          }),
         },
         '&:active': {
-          background: theme.palette[color].active,
           boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.dark}`,
+          background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].main}`,
+          ...(color === 'secondary' && {
+            background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].light}`,
+          }),
         },
       }
     },
@@ -112,35 +118,21 @@ export const MonorailButtonOverrides: Components<Theme>['MuiButton'] = {
       const colorSecondaryStyles: CSSInterpolation = {
         color: theme.palette.secondary.contrastText,
       }
-      const darkModeInteractionStates: CSSInterpolation = {
+      const outlinedButtonInteractionStates: CSSInterpolation = {
         '&:hover': {
           border: 'none',
           boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.light}`,
-          background: theme.palette[color].lowEmphasis.hover,
+          background: `linear-gradient(0deg, ${theme.palette.action.hover} 0%, ${theme.palette.action.hover} 100%), ${theme.palette[color].lowEmphasis.light}`,
           ...(color === 'secondary' && colorSecondaryStyles),
         },
         '&:active': {
-          background: theme.palette[color].lowEmphasis.active,
+          background: `linear-gradient(0deg, ${theme.palette.action.active} 0%, ${theme.palette.action.active} 100%), ${theme.palette[color].lowEmphasis.light}`,
           ...(color === 'secondary' && {
             ...colorSecondaryStyles,
             boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
           }),
         },
       }
-      const lightModeInteractionStates: CSSInterpolation = {
-        '&:hover': {
-          border: 'none',
-          boxShadow: `inset 0 0 0 1px ${theme.palette[color].border.main}`,
-          backgroundColor: theme.palette[color].lowEmphasis.hover,
-        },
-        '&:active': {
-          backgroundColor: theme.palette[color].lowEmphasis.active,
-        },
-      }
-      const outlinedButtonInteractionStates =
-        theme.palette.mode === 'dark'
-          ? darkModeInteractionStates
-          : lightModeInteractionStates
 
       return {
         backgroundColor: theme.palette[color].lowEmphasis.light,

--- a/packages/themes/src/meteor/theme/baseTheme.ts
+++ b/packages/themes/src/meteor/theme/baseTheme.ts
@@ -166,7 +166,7 @@ export const baseTheme = createTheme(
       button: {
         fontSize: FontSize.Button,
         lineHeight: LineHeight.ButtonMedium,
-        fontWeight: FontWeight.Bold,
+        fontWeight: FontWeight.SemiBold,
         textTransform: 'capitalize',
       },
       chip: {

--- a/packages/themes/src/meteor/theme/dark.ts
+++ b/packages/themes/src/meteor/theme/dark.ts
@@ -158,7 +158,7 @@ enum Opacities {
   Focus = 0.16,
   Selected = 0.12,
   Active = 0.16,
-  Disabled = 0.4,
+  Disabled = 0.6,
 }
 
 const action: TypeAction = {
@@ -191,8 +191,8 @@ const palette: PaletteOptions = {
     light: RawColor.Grey400,
     main: RawColor.Grey300,
     dark: RawColor.Grey100,
-    hover: RawColor.Grey400,
-    active: RawColor.Grey500,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey300}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey300}`,
     contrastText: RawColor.Grey900,
 
     lowEmphasis: {
@@ -200,8 +200,8 @@ const palette: PaletteOptions = {
       main: RawColor.Grey600,
       dark: RawColor.Grey500,
       contrastText: RawColor.Grey200,
-      hover: alpha(RawColor.Grey200, action.hoverOpacity),
-      active: alpha(RawColor.Grey200, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey700}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey700}`,
     },
 
     border: {
@@ -231,8 +231,8 @@ const palette: PaletteOptions = {
     light: RawColor.Orange600,
     main: RawColor.Orange500,
     dark: RawColor.Orange400,
-    hover: RawColor.Orange700,
-    active: RawColor.Orange800,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Orange600}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Orange600}`,
     contrastText: RawColor.Orange100,
 
     lowEmphasis: {
@@ -240,8 +240,8 @@ const palette: PaletteOptions = {
       main: RawColor.Orange800,
       dark: RawColor.Orange700,
       contrastText: RawColor.Orange200,
-      hover: alpha(RawColor.Orange200, action.hoverOpacity),
-      active: alpha(RawColor.Orange200, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Orange900}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Orange900}`,
     },
 
     border: {
@@ -272,16 +272,16 @@ const palette: PaletteOptions = {
     main: RawColor.Grey300,
     dark: RawColor.Grey100,
     contrastText: RawColor.Grey900,
-    hover: RawColor.Grey400,
-    active: RawColor.Grey500,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey300}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey300}`,
 
     lowEmphasis: {
       light: RawColor.Grey700,
       main: RawColor.Grey600,
       dark: RawColor.Grey500,
       contrastText: RawColor.Grey200,
-      hover: alpha(RawColor.Grey200, action.hoverOpacity),
-      active: alpha(RawColor.Grey200, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey700}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey700}`,
     },
 
     border: {
@@ -311,8 +311,8 @@ const palette: PaletteOptions = {
     light: RawColor.Green600,
     main: RawColor.Green500,
     dark: RawColor.Green400,
-    hover: RawColor.Green600,
-    active: RawColor.Green700,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Green500}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Green500}`,
     contrastText: RawColor.White,
 
     lowEmphasis: {
@@ -320,8 +320,8 @@ const palette: PaletteOptions = {
       main: RawColor.Green800,
       dark: RawColor.Green700,
       contrastText: RawColor.Green300,
-      hover: alpha(RawColor.Green300, action.hoverOpacity),
-      active: alpha(RawColor.Green300, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Green900}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Green900}`,
     },
 
     border: {
@@ -351,17 +351,17 @@ const palette: PaletteOptions = {
     light: RawColor.Red600,
     main: RawColor.Red500,
     dark: RawColor.Red400,
-    hover: RawColor.Red600,
-    active: RawColor.Red700,
     contrastText: RawColor.White,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Red500}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Red500}`,
 
     lowEmphasis: {
       light: RawColor.Red900,
       main: RawColor.Red800,
       dark: RawColor.Red700,
       contrastText: RawColor.Red200,
-      hover: alpha(RawColor.Red300, action.hoverOpacity),
-      active: alpha(RawColor.Red300, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Red900}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Red900}`,
     },
 
     border: {
@@ -391,17 +391,17 @@ const palette: PaletteOptions = {
     light: RawColor.Yellow500,
     main: RawColor.Yellow400,
     dark: RawColor.Yellow300,
-    hover: RawColor.Yellow500,
-    active: RawColor.Yellow600,
     contrastText: RawColor.Yellow900,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Yellow400}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Yellow400}`,
 
     lowEmphasis: {
       light: RawColor.Yellow800,
       main: RawColor.Yellow700,
       dark: RawColor.Yellow600,
       contrastText: RawColor.Yellow200,
-      hover: alpha(RawColor.Yellow200, action.hoverOpacity),
-      active: alpha(RawColor.Yellow200, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Yellow800}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Yellow800}`,
     },
 
     border: {
@@ -431,8 +431,8 @@ const palette: PaletteOptions = {
     light: RawColor.Blue600,
     main: RawColor.Blue500,
     dark: RawColor.Blue400,
-    hover: RawColor.Blue600,
-    active: RawColor.Blue700,
+    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Blue500}`,
+    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Blue500}`,
     contrastText: RawColor.White,
 
     lowEmphasis: {
@@ -440,8 +440,8 @@ const palette: PaletteOptions = {
       main: RawColor.Blue800,
       dark: RawColor.Blue700,
       contrastText: RawColor.Blue300,
-      hover: alpha(RawColor.Blue300, action.hoverOpacity),
-      active: alpha(RawColor.Blue300, action.activatedOpacity),
+      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Blue900}`,
+      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Blue900}`,
     },
 
     border: {

--- a/packages/themes/src/meteor/theme/dark.ts
+++ b/packages/themes/src/meteor/theme/dark.ts
@@ -191,8 +191,8 @@ const palette: PaletteOptions = {
     light: RawColor.Grey400,
     main: RawColor.Grey300,
     dark: RawColor.Grey100,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey300}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey300}`,
+    hover: RawColor.Grey400,
+    active: RawColor.Grey500,
     contrastText: RawColor.Grey900,
 
     lowEmphasis: {
@@ -200,8 +200,8 @@ const palette: PaletteOptions = {
       main: RawColor.Grey600,
       dark: RawColor.Grey500,
       contrastText: RawColor.Grey200,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey700}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey700}`,
+      hover: alpha(RawColor.Grey200, action.hoverOpacity),
+      active: alpha(RawColor.Grey200, action.activatedOpacity),
     },
 
     border: {
@@ -231,8 +231,8 @@ const palette: PaletteOptions = {
     light: RawColor.Orange600,
     main: RawColor.Orange500,
     dark: RawColor.Orange400,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Orange600}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Orange600}`,
+    hover: RawColor.Orange700,
+    active: RawColor.Orange800,
     contrastText: RawColor.Orange100,
 
     lowEmphasis: {
@@ -240,8 +240,8 @@ const palette: PaletteOptions = {
       main: RawColor.Orange800,
       dark: RawColor.Orange700,
       contrastText: RawColor.Orange200,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Orange900}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Orange900}`,
+      hover: alpha(RawColor.Orange200, action.hoverOpacity),
+      active: alpha(RawColor.Orange200, action.activatedOpacity),
     },
 
     border: {
@@ -271,17 +271,17 @@ const palette: PaletteOptions = {
     light: RawColor.Grey400,
     main: RawColor.Grey300,
     dark: RawColor.Grey100,
+    hover: RawColor.Grey400,
+    active: RawColor.Grey500,
     contrastText: RawColor.Grey900,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey300}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey300}`,
 
     lowEmphasis: {
       light: RawColor.Grey700,
       main: RawColor.Grey600,
       dark: RawColor.Grey500,
       contrastText: RawColor.Grey200,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Grey700}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Grey700}`,
+      hover: alpha(RawColor.Grey200, action.hoverOpacity),
+      active: alpha(RawColor.Grey200, action.activatedOpacity),
     },
 
     border: {
@@ -311,17 +311,17 @@ const palette: PaletteOptions = {
     light: RawColor.Green600,
     main: RawColor.Green500,
     dark: RawColor.Green400,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Green500}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Green500}`,
+    hover: RawColor.Green600,
+    active: RawColor.Green700,
     contrastText: RawColor.White,
 
     lowEmphasis: {
       light: RawColor.Green900,
       main: RawColor.Green800,
       dark: RawColor.Green700,
+      hover: alpha(RawColor.Green300, action.hoverOpacity),
+      active: alpha(RawColor.Green300, action.activatedOpacity),
       contrastText: RawColor.Green300,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Green900}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Green900}`,
     },
 
     border: {
@@ -351,17 +351,17 @@ const palette: PaletteOptions = {
     light: RawColor.Red600,
     main: RawColor.Red500,
     dark: RawColor.Red400,
+    hover: RawColor.Red600,
+    active: RawColor.Red700,
     contrastText: RawColor.White,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Red500}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Red500}`,
 
     lowEmphasis: {
       light: RawColor.Red900,
       main: RawColor.Red800,
       dark: RawColor.Red700,
+      hover: alpha(RawColor.Red300, action.hoverOpacity),
+      active: alpha(RawColor.Red300, action.activatedOpacity),
       contrastText: RawColor.Red200,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Red900}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Red900}`,
     },
 
     border: {
@@ -391,17 +391,17 @@ const palette: PaletteOptions = {
     light: RawColor.Yellow500,
     main: RawColor.Yellow400,
     dark: RawColor.Yellow300,
+    hover: RawColor.Yellow500,
+    active: RawColor.Yellow600,
     contrastText: RawColor.Yellow900,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Yellow400}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Yellow400}`,
 
     lowEmphasis: {
       light: RawColor.Yellow800,
       main: RawColor.Yellow700,
       dark: RawColor.Yellow600,
+      hover: alpha(RawColor.Yellow200, action.hoverOpacity),
+      active: alpha(RawColor.Yellow200, action.activatedOpacity),
       contrastText: RawColor.Yellow200,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Yellow800}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Yellow800}`,
     },
 
     border: {
@@ -431,17 +431,17 @@ const palette: PaletteOptions = {
     light: RawColor.Blue600,
     main: RawColor.Blue500,
     dark: RawColor.Blue400,
-    hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Blue500}`,
-    active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Blue500}`,
+    hover: RawColor.Blue600,
+    active: RawColor.Blue700,
     contrastText: RawColor.White,
 
     lowEmphasis: {
       light: RawColor.Blue900,
       main: RawColor.Blue800,
       dark: RawColor.Blue700,
+      hover: alpha(RawColor.Blue300, action.hoverOpacity),
+      active: alpha(RawColor.Blue300, action.activatedOpacity),
       contrastText: RawColor.Blue300,
-      hover: `linear-gradient(0deg, ${action.hover} 0%, ${action.hover} 100%), ${RawColor.Blue900}`,
-      active: `linear-gradient(0deg, ${action.active} 0%, ${action.active} 100%), ${RawColor.Blue900}`,
     },
 
     border: {

--- a/packages/themes/src/meteor/theme/light.ts
+++ b/packages/themes/src/meteor/theme/light.ts
@@ -230,7 +230,7 @@ const palette: PaletteOptions = {
     light: RawColor.Orange500,
     main: RawColor.Orange600,
     dark: RawColor.Orange800,
-    contrastText: RawColor.Orange700,
+    contrastText: RawColor.White,
     hover: RawColor.Orange700,
     active: RawColor.Orange800,
 

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.129",
+  "version": "3.0.130",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.129",
+  "version": "3.0.130",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
[CFP-2712](https://resolvn.atlassian.net/browse/CFP-2712) - Button theme updates
[CFP-2791](https://resolvn.atlassian.net/browse/CFP-2791) - Fix `secondary.contrastText` token reference

[Designs - Monorail/Button](https://www.figma.com/design/AF2iysvnM1NMDx7oCS93A3/%E2%9A%99%EF%B8%8F-Monorail?node-id=6543-37106&m=dev)

This PR updates the `Button` component's styles in the Meteor theme. 

It also includes a bug fix for secondary buttons light mode by updating `secondary.contrastText` from `RawColor.Orange700` to `RawColor.White`.

[CFP-2712]: https://resolvn.atlassian.net/browse/CFP-2712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CFP-2791]: https://resolvn.atlassian.net/browse/CFP-2791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ