### PR TITLE
[CFP-2714] feat: update split button meteor styling

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.132",
+  "version": "3.0.133",,
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.133",,
+  "version": "3.0.133",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/components/src/ButtonGroup/ButtonGroup.tsx
@@ -10,7 +10,8 @@ declare module '@mui/material/ButtonGroup' {
     warning: true
     error: true
     inherit: false
-    secondary: false
+    secondary: true
+    primary: true
   }
 }
 

--- a/packages/components/src/SplitButton/SplitButton.tsx
+++ b/packages/components/src/SplitButton/SplitButton.tsx
@@ -20,9 +20,11 @@ import {
 } from './splitButtonClasses.js'
 import type { SplitButtonProps } from './splitButtonProps.js'
 
-interface SplitButtonOwnerState extends Omit<SplitButtonProps, 'size'> {
+interface SplitButtonOwnerState
+  extends Omit<SplitButtonProps, 'size' | 'options' | 'slotProps'> {
   size: NonNullable<SplitButtonProps['size']>
 }
+interface SplitButtonMenuOwnerState extends Pick<SplitButtonProps, 'options'> {}
 
 function overridesResolver(
   props: { ownerState: SplitButtonOwnerState },
@@ -55,7 +57,6 @@ function overridesResolver(
     styles.root,
   ]
 }
-
 const SplitButtonRoot = styled(ButtonGroup, {
   name: 'MonorailSplitButton',
   slot: 'Root',
@@ -80,7 +81,7 @@ const SplitButtonRoot = styled(ButtonGroup, {
 const SplitButtonMenu = styled(Menu, {
   name: 'MonorailSplitButton',
   slot: 'Menu',
-})(({ theme }) => ({
+})<{ ownerState: SplitButtonMenuOwnerState }>(({ theme }) => ({
   zIndex: theme.zIndex.tooltip,
 }))
 
@@ -104,6 +105,8 @@ export const SplitButton = React.forwardRef(function SplitButton(inProps, ref) {
     slotProps,
     select = false,
     size = 'medium',
+    color = 'primary',
+    variant = 'contained',
     ...other
   } = props
 
@@ -153,18 +156,24 @@ export const SplitButton = React.forwardRef(function SplitButton(inProps, ref) {
     }
   }
 
-  const ownerState = {
-    ...props,
+  const splitButtonOwnerState = {
+    variant,
+    color,
     size,
   }
+  const menuOwnerState = {
+    options,
+  }
 
-  const classes = useUtilityClasses(ownerState)
+  const classes = useUtilityClasses(splitButtonOwnerState)
 
   return (
     <React.Fragment>
       <SplitButtonRoot
         {...other}
-        ownerState={ownerState}
+        ownerState={splitButtonOwnerState}
+        color={color}
+        variant={variant}
         size={size}
         ref={ref}
         className={clsx(classes.root, props.className)}
@@ -199,6 +208,7 @@ export const SplitButton = React.forwardRef(function SplitButton(inProps, ref) {
         id={menuListId}
         className={clsx(slotProps.menu?.className, classes.menu)}
         {...slotProps.menu}
+        ownerState={menuOwnerState}
         anchorOrigin={
           slotProps.menu?.anchorOrigin ?? {
             horizontal: 'right',

--- a/packages/components/src/SplitButton/splitButtonProps.ts
+++ b/packages/components/src/SplitButton/splitButtonProps.ts
@@ -15,7 +15,8 @@ interface SplitButtonMenuItem extends Omit<MenuItemProps, 'onClick'> {
 }
 
 export interface SplitButtonProps
-  extends Omit<ButtonGroupProps, 'classes' | 'orientation'> {
+  extends Omit<ButtonGroupProps, 'classes' | 'orientation' | 'variant'> {
+  variant?: Exclude<ButtonGroupProps['variant'], 'text'>
   classes?: Partial<SplitButtonClasses>
   /**
    * Sets the SplitButton to select mode. When selecting a MenuItem,

--- a/packages/storybook/src/Button/Button.stories.tsx
+++ b/packages/storybook/src/Button/Button.stories.tsx
@@ -159,13 +159,13 @@ export const VariantsAndColors = story<ButtonProps>(
 export const Sizes = story<ButtonProps>(
   args => (
     <Stack direction="row" spacing={2} alignItems="center">
-      <Button variant="contained" size={'small'} color={args.color}>
+      <Button variant="contained" size="small" color={args.color}>
         Small
       </Button>
-      <Button variant="contained" size={'medium'} color={args.color}>
+      <Button variant="contained" size="medium" color={args.color}>
         Medium
       </Button>
-      <Button variant="contained" size={'large'} color={args.color}>
+      <Button variant="contained" size="large" color={args.color}>
         Large
       </Button>
     </Stack>

--- a/packages/storybook/src/SplitButton/SplitButton.stories.tsx
+++ b/packages/storybook/src/SplitButton/SplitButton.stories.tsx
@@ -19,7 +19,7 @@ const colors = [
   'warning',
   'info',
 ] as const
-const variants = ['contained', 'outlined', 'text'] as const
+const variants = ['contained', 'outlined'] as const
 
 const Template: StoryFn<Partial<SplitButtonProps>> = args => (
   <SplitButton
@@ -61,7 +61,7 @@ export const Colors = () => (
   </Stack>
 )
 
-export const ColorsAndVariants = () => {
+export const Variants = () => {
   return variants.map(variant => {
     return (
       <Box key={variant}>

--- a/packages/storybook/src/SplitButton/SplitButton.stories.tsx
+++ b/packages/storybook/src/SplitButton/SplitButton.stories.tsx
@@ -3,12 +3,23 @@ import { Stack } from '@mui/material'
 import type { StoryFn } from '@storybook/react'
 
 import type { SplitButtonProps } from '@monorail/components'
-import { SplitButton } from '@monorail/components'
+import { Box, SplitButton, Typography } from '@monorail/components'
+import { capitalize } from '@monorail/utils'
 
 export default {
   title: 'Inputs/SplitButton',
   component: SplitButton,
 }
+
+const colors = [
+  'primary',
+  'secondary',
+  'success',
+  'error',
+  'warning',
+  'info',
+] as const
+const variants = ['contained', 'outlined', 'text'] as const
 
 const Template: StoryFn<Partial<SplitButtonProps>> = args => (
   <SplitButton
@@ -40,10 +51,32 @@ Default.args = {
   variant: 'contained',
 }
 
-export const Sizes = () => (
+export const Colors = () => (
   <Stack direction="column" gap={4}>
-    <Template size="small" variant="contained" />
-    <Template size="medium" variant="contained" />
-    <Template size="large" variant="contained" />
+    <Template color="primary" variant="contained" />
+    <Template color="secondary" variant="contained" />
+    <Template color="error" variant="contained" />
+    <Template color="success" variant="contained" />
+    <Template color="warning" variant="contained" />
   </Stack>
 )
+
+export const ColorsAndVariants = () => {
+  return variants.map(variant => {
+    return (
+      <Box key={variant}>
+        <Typography variant="h1">{capitalize(variant)}</Typography>
+        {colors.map(color => (
+          <Stack direction="row" spacing={2} my={2} key={`${variant}-${color}`}>
+            <Template variant={variant} color={color} size="medium">
+              {color}
+            </Template>
+            <Template disabled variant={variant} color={color} size="medium">
+              {color}
+            </Template>
+          </Stack>
+        ))}
+      </Box>
+    )
+  })
+}

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.133",,
+  "version": "3.0.133",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.132",
+  "version": "3.0.133",,
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
@@ -1,5 +1,5 @@
 import type { Components, Theme } from '@mui/material'
-import { buttonClasses } from '@mui/material'
+import { buttonClasses, menuClasses } from '@mui/material'
 
 import { type SplitButtonProps } from '@monorail/components'
 
@@ -37,17 +37,8 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
             }),
           }),
           ...(variant === 'outlined' && {
-            borderRight: `1px solid ${theme.palette[color].border.light}`,
             color: theme.palette[color].lowEmphasis.contrastText,
-            '&:hover': {
-              borderRight: `1px solid ${theme.palette[color].border.light}`,
-            },
-            '&:active': {
-              borderRight: `1px solid ${theme.palette[color].border.light}`,
-            },
-            [`&.${buttonClasses.disabled}`]: {
-              borderRight: `1px solid ${theme.palette[color].border.light}`,
-            },
+            [`&.${buttonClasses.disabled}`]: {},
           }),
         }
       },
@@ -72,6 +63,11 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
             color: theme.palette[color].lowEmphasis.contrastText,
           }),
         }
+      },
+      menu: {
+        [`& .${menuClasses.paper}`]: {
+          margin: 0,
+        },
       },
     },
   }

--- a/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
@@ -1,0 +1,77 @@
+import type { Components, Theme } from '@mui/material'
+import { buttonClasses } from '@mui/material'
+
+import { type SplitButtonProps } from '@monorail/components'
+
+export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButton'] =
+  {
+    defaultProps: {
+      disableElevation: true,
+      disableRipple: true,
+      disableFocusRipple: true,
+      fullWidth: false,
+      variant: 'contained',
+    },
+    styleOverrides: {
+      primaryButton: ({
+        ownerState: { color = 'primary', variant = 'contained' },
+        theme,
+      }: {
+        ownerState: {
+          color?: SplitButtonProps['color']
+          variant?: SplitButtonProps['variant']
+        }
+        theme: Theme
+      }) => {
+        return {
+          zIndex: 1,
+          ...(variant === 'contained' && {
+            color: theme.palette[color].contrastText,
+            borderRight: `1px solid ${theme.palette.divider}`,
+            ...(color === 'primary' && {
+              borderRight: `1px solid ${theme.palette[color].border.light}`,
+            }),
+            ...(color === 'secondary' && {
+              borderRight: `1px solid ${theme.palette[color].border.dark}`,
+              color: theme.palette.common.white,
+            }),
+          }),
+          ...(variant === 'outlined' && {
+            borderRight: `1px solid ${theme.palette[color].border.light}`,
+            color: theme.palette[color].lowEmphasis.contrastText,
+            '&:hover': {
+              borderRight: `1px solid ${theme.palette[color].border.light}`,
+            },
+            '&:active': {
+              borderRight: `1px solid ${theme.palette[color].border.light}`,
+            },
+            [`&.${buttonClasses.disabled}`]: {
+              borderRight: `1px solid ${theme.palette[color].border.light}`,
+            },
+          }),
+        }
+      },
+      secondaryButton: ({
+        ownerState: { color = 'primary', variant = 'contained' },
+        theme,
+      }: {
+        ownerState: {
+          color?: SplitButtonProps['color']
+          variant?: SplitButtonProps['variant']
+        }
+        theme: Theme
+      }) => {
+        return {
+          ...(variant === 'contained' && {
+            color: theme.palette[color].contrastText,
+            ...(color === 'secondary' && {
+              color: theme.palette.common.white,
+            }),
+          }),
+          ...(variant === 'outlined' && {
+            color: theme.palette[color].lowEmphasis.contrastText,
+          }),
+        }
+      },
+    },
+  }

--- a/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
@@ -1,5 +1,5 @@
 import type { Components, Theme } from '@mui/material'
-import { buttonClasses, menuClasses } from '@mui/material'
+import { buttonGroupClasses, menuClasses } from '@mui/material'
 
 import { type SplitButtonProps } from '@monorail/components'
 
@@ -35,10 +35,18 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
               borderRight: `1px solid ${theme.palette[color].border.dark}`,
               color: theme.palette.common.white,
             }),
+            [`&.${buttonGroupClasses.disabled}`]: {
+              borderRight: `1px solid ${theme.palette.divider}`,
+              ...(color === 'primary' && {
+                borderRight: `1px solid ${theme.palette[color].border.light}`,
+              }),
+              ...(color === 'secondary' && {
+                borderRight: `1px solid ${theme.palette[color].border.dark}`,
+              }),
+            },
           }),
           ...(variant === 'outlined' && {
             color: theme.palette[color].lowEmphasis.contrastText,
-            [`&.${buttonClasses.disabled}`]: {},
           }),
         }
       },

--- a/packages/themes/src/meteor/theme/themeComponents.ts
+++ b/packages/themes/src/meteor/theme/themeComponents.ts
@@ -42,6 +42,7 @@ import { MonorailOutlinedInputOverrides } from '../components/OutlinedInput/them
 import { MonorailPaginationItemOverrides } from '../components/PaginationItem/themeOverrides.js'
 import { MonorailSelectionFooterOverrides } from '../components/SelectionFooter/themeOverrides.js'
 import { MonorailSkeletonOverrides } from '../components/Skeleton/themeOverrides.js'
+import { MonorailSplitButtonOverrides } from '../components/SplitButton/themeOverrides.js'
 import { MonorailStepIconOverrides } from '../components/StepIcon/themeOverrides.js'
 import { MonorailStepLabelOverrides } from '../components/StepLabel/themeOverrides.js'
 import { MonorailSwitchOverrides } from '../components/Switch/themeOverrides.js'
@@ -97,6 +98,7 @@ export const getThemeComponents = (
   MuiOutlinedInput: MonorailOutlinedInputOverrides,
   MuiPaginationItem: MonorailPaginationItemOverrides,
   MuiSkeleton: MonorailSkeletonOverrides,
+  MonorailSplitButton: MonorailSplitButtonOverrides,
   MuiStepIcon: MonorailStepIconOverrides,
   MuiStepLabel: MonorailStepLabelOverrides,
   MuiSwitch: MonorailSwitchOverrides,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.133",,
+  "version": "3.0.133",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.132",
+  "version": "3.0.133",,
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.133",,
+  "version": "3.0.133",
   "license": "Apache-2.0",
   "exports": {
     "./*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.132",
+  "version": "3.0.133",,
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
[CFP-2714](https://resolvn.atlassian.net/browse/CFP-2714)
[Designs](https://www.figma.com/file/AF2iysvnM1NMDx7oCS93A3/%E2%9A%99%EF%B8%8F-Monorail?type=design&node-id=6543%3A39713&mode=dev)

This PR introduces new override styling for the contained and outline variants of the meteor SplitButton component.

[CFP-2714]: https://resolvn.atlassian.net/browse/CFP-2714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ