### PR TITLE
[CFP-2730] adds theme overrides to input components

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.133",
+  "version": "3.0.134",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
+++ b/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
@@ -67,12 +67,6 @@ export const MonorailAutocompleteOverrides: Components<Theme>['MuiAutocomplete']
             right: 7,
           },
         },
-        [`& .${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: theme.palette.outlinedBorder,
-          '&:hover': {
-            borderColor: theme.palette.default.border.main,
-          },
-        },
         ...(size === 'large' && {
           [`&.${autocompleteClasses.hasPopupIcon}.${autocompleteClasses.hasClearIcon} .${outlinedInputClasses.root}`]:
             { paddingRight: theme.spacing(21.25) },

--- a/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
@@ -7,7 +7,7 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
     root: ({ ownerState: { color = 'primary', size = 'medium' }, theme }) => {
       return {
         [`&.${inputBaseClasses.focused}`]: {
-          boxShadow: `0 0 0 3px ${theme.palette[color].focusRing.outer}`,
+          boxShadow: `0 0 0 2px ${theme.palette[color].focusRing.outer}`,
           [`& > fieldset.${outlinedInputClasses.notchedOutline}`]: {
             borderColor: `${theme.palette.default.border.main}`,
             borderWidth: '1px',
@@ -31,7 +31,7 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
     }),
     error: ({ theme }) => ({
       [`&.${inputBaseClasses.focused}`]: {
-        boxShadow: `0 0 0 3px ${theme.palette.error.border.main}`,
+        boxShadow: `0 0 0 2px ${theme.palette.error.border.main}`,
         [`& > fieldset.${outlinedInputClasses.notchedOutline}`]: {
           borderColor: `${theme.palette.error.border.main}`,
           borderWidth: '1px',

--- a/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/InputBase/themeOverrides.ts
@@ -31,9 +31,15 @@ export const MonorailInputBaseOverrides: Components<Theme>['MuiInputBase'] = {
     }),
     error: ({ theme }) => ({
       [`&.${inputBaseClasses.focused}`]: {
-        boxShadow: `0 0 0 3px ${theme.palette.error.focusRing.outer}`,
+        boxShadow: `0 0 0 3px ${theme.palette.error.border.main}`,
         [`& > fieldset.${outlinedInputClasses.notchedOutline}`]: {
-          borderColor: `${theme.palette.error.focusRing.inner}`,
+          borderColor: `${theme.palette.error.border.main}`,
+          borderWidth: '1px',
+        },
+      },
+      [`&:hover`]: {
+        [`& > fieldset.${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: `${theme.palette.error.border.dark}`,
           borderWidth: '1px',
         },
       },

--- a/packages/themes/src/meteor/components/InputLabel/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/InputLabel/themeOverrides.ts
@@ -13,7 +13,7 @@ export const MonorailInputLabelOverrides: Components<Theme>['MuiInputLabel'] = {
         top: 'auto',
         transform: 'none',
         background: 'transparent',
-        color: theme.palette.default.main,
+        color: theme.palette.text.secondary,
         marginBottom: theme.spacing(0.5),
         ...theme.typography.inputLabel,
       }

--- a/packages/themes/src/meteor/components/OutlinedInput/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/OutlinedInput/themeOverrides.ts
@@ -10,20 +10,24 @@ export const MonorailOutlinedInputOverrides: Components<Theme>['MuiOutlinedInput
       notched: false,
     },
     styleOverrides: {
-      root: ({ ownerState, theme }) => ({
-        ...(ownerState.disabled === false &&
-          ownerState.error === false && {
-            borderColor: theme.palette.outlinedBorder,
-            [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
-              borderColor: theme.palette.default.border.main,
-            },
-          }),
+      root: ({ theme }) => ({
+        [`&.${outlinedInputClasses.disabled} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.action.disabled,
+          },
+        [`&.${outlinedInputClasses.error} .${outlinedInputClasses.notchedOutline}`]:
+          {
+            borderColor: theme.palette.error.border.main,
+          },
+        [`&:hover .${outlinedInputClasses.notchedOutline}`]: {
+          borderColor: theme.palette.default.border.main,
+        },
         [`&.Mui-focusVisible`]: {
           borderColor: theme.palette.default.border.main,
         },
       }),
       notchedOutline: ({ theme }) => ({
-        borderColor: theme.palette.outlinedBorder,
+        borderColor: theme.palette.default.border.light,
       }),
       multiline: {
         padding: 0,

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.133",
+  "version": "3.0.134",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.133",
+  "version": "3.0.134",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
[Ticket](https://resolvn.atlassian.net/browse/CFP-2730)
[Design](https://www.figma.com/file/AF2iysvnM1NMDx7oCS93A3/%E2%9A%99%EF%B8%8F-Monorail?type=design&node-id=22449-40077&mode=design&t=a9rgHwjtvRSe7j5C-11)

This PR updates `themeOverride` colors for base input elements used in TextField, Select, Autocomplete, and Search components.