### PR TITLE
fix(ResizableDrawer): subtract adjacent element's width when resizing

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.138",
+  "version": "3.0.139",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/ResizeHandle/ResizeHandle.tsx
+++ b/packages/components/src/ResizeHandle/ResizeHandle.tsx
@@ -135,7 +135,8 @@ const ResizeHandleGrip = styled('div', {
       width: theme.spacing(3),
       height: theme.spacing(12),
       borderRadius: 12,
-      top: 'calc(50% - 24px)',
+      top: 'calc(min(50%, 50vh) - 24px)',
+      // top: 'calc(50% - 24px)',
       '&::before': {
         content: '""',
         position: 'absolute',

--- a/packages/components/src/ResizeHandle/ResizeHandle.tsx
+++ b/packages/components/src/ResizeHandle/ResizeHandle.tsx
@@ -136,7 +136,6 @@ const ResizeHandleGrip = styled('div', {
       height: theme.spacing(12),
       borderRadius: 12,
       top: 'calc(min(50%, 50vh) - 24px)',
-      // top: 'calc(50% - 24px)',
       '&::before': {
         content: '""',
         position: 'absolute',

--- a/packages/storybook/src/Drawer/Drawer.stories.tsx
+++ b/packages/storybook/src/Drawer/Drawer.stories.tsx
@@ -8,7 +8,11 @@ import MenuIcon from '@mui/icons-material/Menu'
 import type { CSSObject, Theme } from '@mui/material'
 import { styled, useTheme } from '@mui/material'
 
-import type { AppBarProps, DrawerProps } from '@monorail/components'
+import type {
+  AppBarProps,
+  DrawerProps,
+  ResizableDrawerProps,
+} from '@monorail/components'
 import {
   AppBar,
   Box,
@@ -24,9 +28,11 @@ import {
   ListItemIcon,
   ListItemText,
   ResizableDrawer,
+  Stack,
   Toolbar,
   Typography,
 } from '@monorail/components'
+import { Home } from '@monorail/components/icons'
 
 import { story } from '../helpers/storybook.js'
 
@@ -465,122 +471,134 @@ export const PersistentDrawer = story<DrawerProps>(() => {
  *
  * Persistent navigation drawers are acceptable for all sizes larger than mobile. They are not recommended for apps with multiple levels of hierarchy that require using an up arrow for navigation.
  */
-export const ResizableDrawer_ = story<DrawerProps>(
+export const ResizableDrawer_ = story<ResizableDrawerProps>(
   () => {
     const [open, setOpen] = React.useState(false)
-    return (
-      <Box overflow="hidden" height="100%" sx={{ display: 'flex' }}>
-        <CssBaseline />
-        <GlobalStyles
-          styles={{
-            'html, body, #root': {
-              height: '100%',
-            },
-          }}
-        />
-        <ResizableDrawer
-          variant="persistent"
-          onClose={() => setOpen(false)}
-          open={open}
-          slotProps={{
-            paper: {
-              elevation: 16,
-            },
-          }}
-        >
-          <Toolbar />
-          <Divider />
-          <List>
-            {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
-              <ListItem key={text} disablePadding>
-                <ListItemButton sx={{ width: '100%' }}>
-                  <ListItemIcon>
-                    {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={text}
-                    sx={{
-                      '& > span': {
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      },
-                    }}
-                  />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-          <Divider />
-          <List>
-            {['All mail', 'Trash', 'Spam'].map((text, index) => (
-              <ListItem key={text} disablePadding>
-                <ListItemButton sx={{ width: '100%' }}>
-                  <ListItemIcon>
-                    {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                  </ListItemIcon>
-                  <ListItemText
-                    primary={text}
-                    sx={{
-                      '& > span': {
-                        whiteSpace: 'nowrap',
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                      },
-                    }}
-                  />
-                </ListItemButton>
-              </ListItem>
-            ))}
-          </List>
-        </ResizableDrawer>
 
-        <Box
-          component="main"
-          sx={{ flexGrow: 1, bgcolor: 'background.default' }}
+    return (
+      <Stack direction="row">
+        <Stack
+          minWidth={64}
+          flexGrow={1}
+          alignItems="center"
+          bgcolor="common.black"
+          py={4}
         >
-          <AppBar sx={{ position: 'relative' }}>
-            <Toolbar>
-              <Typography variant="h3" noWrap component="div">
-                Resizable drawer
+          <Home
+            fontSize="large"
+            sx={theme => ({ fill: theme.palette.common.white })}
+          />
+        </Stack>
+
+        <Box overflow="hidden" height="100%" sx={{ display: 'flex' }}>
+          <CssBaseline />
+          <GlobalStyles
+            styles={{
+              'html, body, #root': {
+                height: '100%',
+              },
+            }}
+          />
+          <ResizableDrawer
+            variant="persistent"
+            onClose={() => setOpen(false)}
+            open={open}
+            slotProps={{
+              paper: {
+                elevation: 16,
+              },
+            }}
+          >
+            <Toolbar />
+            <Divider />
+            <List>
+              {['Inbox', 'Starred', 'Send email', 'Drafts'].map(
+                (text, index) => (
+                  <ListItem key={text} disablePadding>
+                    <ListItemButton sx={{ width: '100%' }}>
+                      <ListItemIcon>
+                        {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                      </ListItemIcon>
+                      <ListItemText
+                        primary={text}
+                        sx={{
+                          '& > span': {
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                          },
+                        }}
+                      />
+                    </ListItemButton>
+                  </ListItem>
+                ),
+              )}
+            </List>
+            <Divider />
+            <List>
+              {['All mail', 'Trash', 'Spam'].map((text, index) => (
+                <ListItem key={text} disablePadding>
+                  <ListItemButton sx={{ width: '100%' }}>
+                    <ListItemIcon>
+                      {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={text}
+                      sx={{
+                        '& > span': {
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        },
+                      }}
+                    />
+                  </ListItemButton>
+                </ListItem>
+              ))}
+            </List>
+          </ResizableDrawer>
+
+          <Box
+            component="main"
+            sx={{ flexGrow: 1, bgcolor: 'background.default' }}
+          >
+            <Box sx={{ p: 3, overflowY: 'auto' }}>
+              <Button onClick={() => setOpen(!open)}>Open</Button>
+              <Typography paragraph>
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+                eiusmod tempor incididunt ut labore et dolore magna aliqua.
+                Rhoncus dolor purus non enim praesent elementum facilisis leo
+                vel. Risus at ultrices mi tempus imperdiet. Semper risus in
+                hendrerit gravida rutrum quisque non tellus. Convallis convallis
+                tellus id interdum velit laoreet id donec ultrices. Odio morbi
+                quis commodo odio aenean sed adipiscing. Amet nisl suscipit
+                adipiscing bibendum est ultricies integer quis. Cursus euismod
+                quis viverra nibh cras. Metus vulputate eu scelerisque felis
+                imperdiet proin fermentum leo. Mauris commodo quis imperdiet
+                massa tincidunt. Cras tincidunt lobortis feugiat vivamus at
+                augue. At augue eget arcu dictum varius duis at consectetur
+                lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa
+                sapien faucibus et molestie ac.
               </Typography>
-            </Toolbar>
-          </AppBar>
-          <Box sx={{ p: 3, overflowY: 'auto' }}>
-            <Button onClick={() => setOpen(!open)}>Open</Button>
-            <Typography paragraph>
-              Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-              eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              Rhoncus dolor purus non enim praesent elementum facilisis leo vel.
-              Risus at ultrices mi tempus imperdiet. Semper risus in hendrerit
-              gravida rutrum quisque non tellus. Convallis convallis tellus id
-              interdum velit laoreet id donec ultrices. Odio morbi quis commodo
-              odio aenean sed adipiscing. Amet nisl suscipit adipiscing bibendum
-              est ultricies integer quis. Cursus euismod quis viverra nibh cras.
-              Metus vulputate eu scelerisque felis imperdiet proin fermentum
-              leo. Mauris commodo quis imperdiet massa tincidunt. Cras tincidunt
-              lobortis feugiat vivamus at augue. At augue eget arcu dictum
-              varius duis at consectetur lorem. Velit sed ullamcorper morbi
-              tincidunt. Lorem donec massa sapien faucibus et molestie ac.
-            </Typography>
-            <Typography paragraph>
-              Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-              ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-              elementum integer enim neque volutpat ac tincidunt. Ornare
-              suspendisse sed nisi lacus sed viverra tellus. Purus sit amet
-              volutpat consequat mauris. Elementum eu facilisis sed odio morbi.
-              Euismod lacinia at quis risus sed vulputate odio. Morbi tincidunt
-              ornare massa eget egestas purus viverra accumsan in. In hendrerit
-              gravida rutrum quisque non tellus orci ac. Pellentesque nec nam
-              aliquam sem et tortor. Habitant morbi tristique senectus et.
-              Adipiscing elit duis tristique sollicitudin nibh sit. Ornare
-              aenean euismod elementum nisi quis eleifend. Commodo viverra
-              maecenas accumsan lacus vel facilisis. Nulla posuere sollicitudin
-              aliquam ultrices sagittis orci a.
-            </Typography>
+              <Typography paragraph>
+                Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
+                ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
+                elementum integer enim neque volutpat ac tincidunt. Ornare
+                suspendisse sed nisi lacus sed viverra tellus. Purus sit amet
+                volutpat consequat mauris. Elementum eu facilisis sed odio
+                morbi. Euismod lacinia at quis risus sed vulputate odio. Morbi
+                tincidunt ornare massa eget egestas purus viverra accumsan in.
+                In hendrerit gravida rutrum quisque non tellus orci ac.
+                Pellentesque nec nam aliquam sem et tortor. Habitant morbi
+                tristique senectus et. Adipiscing elit duis tristique
+                sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
+                eleifend. Commodo viverra maecenas accumsan lacus vel facilisis.
+                Nulla posuere sollicitudin aliquam ultrices sagittis orci a.
+              </Typography>
+            </Box>
           </Box>
         </Box>
-      </Box>
+      </Stack>
     )
   },
   {

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.138",
+  "version": "3.0.139",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.138",
+  "version": "3.0.139",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.138",
+  "version": "3.0.139",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
[CFP-2850](https://resolvn.atlassian.net/browse/CFP-2850)

On resize, the `ResizableDrawer` shifts if an adjacent element is present. This PR includes a fix by subtracting the adjacent element's width from the drawer's updated width.

The resize handle's alignment was also updated so that it's always visible to the user.

## Before

https://github.com/Simspace/monorail/assets/35754959/50f18856-3a30-4822-a59d-7a612590f1d3



## After

https://github.com/Simspace/monorail/assets/35754959/253cfcf9-4c45-4ddb-bafc-c19ae746947b




[CFP-2850]: https://resolvn.atlassian.net/browse/CFP-2850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ