### PR TITLE
[PRTL-3923]: Fixed theme override for meteor split button

### DIFF
--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.139",
+  "version": "3.0.140",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
@@ -24,7 +24,6 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
         theme: Theme
       }) => {
         return {
-          zIndex: 1,
           ...(variant === 'contained' && {
             color: theme.palette[color].contrastText,
             borderRight: `1px solid ${theme.palette.divider}`,
@@ -69,6 +68,7 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
           }),
           ...(variant === 'outlined' && {
             color: theme.palette[color].lowEmphasis.contrastText,
+            marginLeft: 0
           }),
         }
       },

--- a/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/SplitButton/themeOverrides.ts
@@ -68,7 +68,7 @@ export const MonorailSplitButtonOverrides: Components<Theme>['MonorailSplitButto
           }),
           ...(variant === 'outlined' && {
             color: theme.palette[color].lowEmphasis.contrastText,
-            marginLeft: 0
+            marginLeft: 0,
           }),
         }
       },


### PR DESCRIPTION
# Summary

The MUI `ButtonGroup` component overlaps the buttons with a negative margin equal to the button border. Thus when hovering the left button took precedence over the right button overlapping its left border.

# Recording

https://github.com/Simspace/monorail/assets/160646444/1bc325e3-221f-4111-9ba3-91fbe11d4c18


