### PR TITLE
[No Ticket] fix: add totalCount to non-grouped virtualized autocomplete

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.0.152",
+  "version": "3.0.153",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/VirtualizedAutocomplete/VirtualizedAutocomplete.tsx
+++ b/packages/components/src/VirtualizedAutocomplete/VirtualizedAutocomplete.tsx
@@ -240,6 +240,7 @@ export const VirtualizedListboxComponent = React.forwardRef(
           />
         ) : (
           <Virtuoso
+            totalCount={items.length}
             scrollerRef={scrollerRefCallback}
             totalListHeightChanged={handleTotalListHeightChanged}
             context={{

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.0.152",
+  "version": "3.0.153",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.0.152",
+  "version": "3.0.153",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.0.152",
+  "version": "3.0.153",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
Fixes a bug where a non-grouped `VirtualizedAutocomplete` would not render any items.