### PR TITLE
[NG-480] feat: meteor paper overlay alpha values

### DIFF
--- a/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
+++ b/packages/themes/src/meteor/components/Autocomplete/themeOverrides.tsx
@@ -28,6 +28,9 @@ export const MonorailAutocompleteOverrides: Components<Theme>['MuiAutocomplete']
             visibility: 'visible',
           },
         } as Partial<IconButtonProps>,
+        paper: {
+          elevation: 6,
+        },
       },
       ChipProps: {
         clickable: true,

--- a/packages/themes/src/meteor/components/Paper/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/Paper/themeOverrides.ts
@@ -1,0 +1,63 @@
+import type { Components, Theme } from '@mui/material'
+import { alpha } from '@mui/material'
+
+export const MonorailPaperOverrides: Components<Theme>['MuiPaper'] = {
+  styleOverrides: {
+    root: ({
+      theme,
+      ownerState: { elevation = 0, variant = 'elevation' },
+    }) => ({
+      ...(variant === 'elevation' && {
+        boxShadow: theme.shadows[elevation],
+        ...(theme.palette.mode === 'dark' && {
+          backgroundImage: `linear-gradient(${alpha(
+            theme.palette.common.white,
+            getOverlayAlphaMap(elevation),
+          )}, ${alpha(
+            theme.palette.common.white,
+            getOverlayAlphaMap(elevation),
+          )})`,
+        }),
+      }),
+    }),
+  },
+}
+
+// prettier-ignore
+/**
+ * Returns the overlay alpha value based on the given elevation.
+ *
+ * @param elevation - The elevation value.
+ * @returns The overlay alpha value for the given elevation.
+ */
+export function getOverlayAlphaMap(elevation: number) {
+  const alphaMap = [
+    0,    // Elevation 0
+    0.02, // Elevation 1
+    0.03, // Elevation 2
+    0.04, // Elevation 3
+    0.05, // Elevation 4
+    0.05, // Elevation 5
+    0.08, // Elevation 6
+    0.08, // Elevation 7
+    0.1,  // Elevation 8
+    0.1,  // Elevation 9
+    0.1,  // Elevation 10
+    0.1,  // Elevation 11
+    0.12, // Elevation 12
+    0.12, // Elevation 13
+    0.12, // Elevation 14
+    0.12, // Elevation 15
+    0.14, // Elevation 16
+    0.14, // Elevation 17
+    0.14, // Elevation 18
+    0.14, // Elevation 19
+    0.14, // Elevation 20
+    0.14, // Elevation 21
+    0.14, // Elevation 22
+    0.14, // Elevation 23
+    0.2   // Elevation 24
+  ];
+
+  return alphaMap[elevation] ?? 0.1;
+}

--- a/packages/themes/src/meteor/theme/themeComponents.ts
+++ b/packages/themes/src/meteor/theme/themeComponents.ts
@@ -42,6 +42,7 @@ import { MonorailListItemTextOverrides } from '../components/ListItemText/themeO
 import { MonorailMenuItemOverrides } from '../components/MenuItem/themeOverrides.js'
 import { MonorailOutlinedInputOverrides } from '../components/OutlinedInput/themeOverrides.js'
 import { MonorailPaginationItemOverrides } from '../components/PaginationItem/themeOverrides.js'
+import { MonorailPaperOverrides } from '../components/Paper/themeOverrides.js'
 import { MonorailPopoverOverrides } from '../components/Popover/themeOverrides.js'
 import { MonorailPopupOverrides } from '../components/Popup/themeOverrides.js'
 import { MonorailSelectionFooterOverrides } from '../components/SelectionFooter/themeOverrides.js'
@@ -105,6 +106,7 @@ export const getThemeComponents = (
   MuiMenuItem: MonorailMenuItemOverrides,
   MuiOutlinedInput: MonorailOutlinedInputOverrides,
   MuiPaginationItem: MonorailPaginationItemOverrides,
+  MuiPaper: MonorailPaperOverrides,
   MuiPopover: MonorailPopoverOverrides,
   MuiSkeleton: MonorailSkeletonOverrides,
   MuiSnackbar: MonorailSnackbarOverrides,


### PR DESCRIPTION
https://resolvn.atlassian.net/browse/NG-480

Notion: [Dark Mode Updates (Elevations)](https://www.notion.so/simspace/Dark-Mode-Updates-3ada6d9a3ddd4d72b7fab780ec8f1a4d?pvs=4#08d6a7ad8cf149ce9ea217f9025461aa)

This PR overrides MUI's built-in `getOverlayAlpha` for the `Paper` component in Meteor dark mode.

### After
<img width="1574" alt="image" src="https://github.com/user-attachments/assets/e3de2677-ab9d-4367-86c1-b1e58035cef8">


### Before
<img width="1574" alt="image" src="https://github.com/user-attachments/assets/9534607d-bd2b-4dbc-90ae-8952f164b7f2">
