### PR TITLE
feat: [NO-TICKET] enhance PasswordTextField to accept slots

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/PasswordTextField/PasswordTextField.tsx
+++ b/packages/components/src/PasswordTextField/PasswordTextField.tsx
@@ -71,6 +71,7 @@ export const PasswordTextField = React.forwardRef(function PasswordTextField(
     onVisibilityChange,
     slotProps,
     inputRef,
+    slots,
     isVisible: controlledState,
     defaultIsVisible: defaultState,
     ...other
@@ -94,6 +95,10 @@ export const PasswordTextField = React.forwardRef(function PasswordTextField(
     [isVisible, onVisibilityChange, setIsVisible, slotProps?.iconButton],
   )
 
+  const VisibilityIconComponent = slots?.visibilityIcon ?? VisibilityIcon
+  const VisibilityOffIconComponent =
+    slots?.visibilityOffIcon ?? VisibilityOffIcon
+
   const endAdornment = React.useMemo(() => {
     return (
       <IconButton
@@ -106,12 +111,12 @@ export const PasswordTextField = React.forwardRef(function PasswordTextField(
         className={classes.toggleVisibilityButton}
       >
         {isVisible ? (
-          <VisibilityIcon
+          <VisibilityIconComponent
             {...slotProps?.visibilityIcon}
             className={classes.visibilityIcon}
           />
         ) : (
-          <VisibilityOffIcon
+          <VisibilityOffIconComponent
             {...slotProps?.visibilityOffIcon}
             className={classes.visibilityOffIcon}
           />
@@ -119,6 +124,8 @@ export const PasswordTextField = React.forwardRef(function PasswordTextField(
       </IconButton>
     )
   }, [
+    VisibilityIconComponent,
+    VisibilityOffIconComponent,
     classes.toggleVisibilityButton,
     classes.visibilityIcon,
     classes.visibilityOffIcon,
@@ -143,11 +150,14 @@ export const PasswordTextField = React.forwardRef(function PasswordTextField(
       inputRef={inputRef}
       ref={ref}
       type={type}
-      InputProps={{
-        ...props.InputProps,
-        endAdornment,
-      }}
       className={classes.root}
+      slotProps={{
+        ...slotProps,
+        input: {
+          ...slotProps?.input,
+          endAdornment,
+        },
+      }}
       {...other}
     />
   )

--- a/packages/components/src/PasswordTextField/PasswordTextFieldProps.ts
+++ b/packages/components/src/PasswordTextField/PasswordTextFieldProps.ts
@@ -23,7 +23,7 @@ export interface PasswordTextFieldProps
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
     isVisible: boolean,
   ) => void
-  slotProps?: {
+  slotProps?: TextFieldProps['slotProps'] & {
     /**
      * Props applied to the visibility Icon.
      */
@@ -36,5 +36,16 @@ export interface PasswordTextFieldProps
      * Props applied to the IconButton.
      */
     iconButton?: Partial<IconButtonProps>
+  }
+  slots?: TextFieldProps['slots'] & {
+    /**
+     * The component to render for the "visibility on" icon.
+     */
+    visibilityIcon?: React.ElementType
+
+    /**
+     * The component to render for the "visibility off" icon.
+     */
+    visibilityOffIcon?: React.ElementType
   }
 }

--- a/packages/storybook/src/PasswordTextField/PasswordTextField.stories.tsx
+++ b/packages/storybook/src/PasswordTextField/PasswordTextField.stories.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Lock } from '@mui/icons-material'
 import Box from '@mui/material/Box'
 import { action } from '@storybook/addon-actions'
 import type { StoryObj } from '@storybook/react'
@@ -49,6 +50,40 @@ export const ControlledVsUncontrolled: StoryObj<typeof PasswordTextField> = {
           onVisibilityChange={action('onVisibilityChange')}
           defaultIsVisible={false}
           {...restArgs}
+        />
+      </Box>
+    )
+  },
+}
+
+export const CustomIcon: StoryObj<typeof PasswordTextField> = {
+  render: args => {
+    return (
+      <Box
+        component="form"
+        sx={{
+          '& > :not(style)': { m: 1, width: '25ch' },
+        }}
+        noValidate
+        autoComplete="off"
+      >
+        <PasswordTextField
+          id="custom-icon"
+          label="Custom Icon"
+          defaultValue="bar"
+          disabled
+          onVisibilityChange={action('onVisibilityChange')}
+          defaultIsVisible={false}
+          slots={{
+            visibilityOffIcon: Lock,
+          }}
+          slotProps={{
+            iconButton: { disabled: true },
+            visibilityOffIcon: {
+              sx: theme => ({ color: theme.palette.default.main }),
+            },
+          }}
+          {...args}
         />
       </Box>
     )

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
## Summary

This PR enhances the PasswordTextField component to accept slots for the visibilityIcon and visibilityOffIcon.

![image](https://github.com/user-attachments/assets/8ed019c7-9614-4e61-ac42-ed4a4a07a037)
