### PR TITLE
[PRTL-4583] feat: Time picker

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/components/src/DateTimePicker/DateTimePicker.tsx
@@ -19,6 +19,13 @@ export const DateTimePicker: typeof MuiDateTimePicker = React.forwardRef(
   (props, ref) => (
     <MuiDateTimePicker
       ref={ref}
+      /**
+       * The reason for this is here instead of in 
+       * packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
+       * is because the layout padding depends on whether the component is wrapping a DateTimePicker or a 
+       * DesktopDateTimePicker. The padding is different for each.
+       */
+      slotProps={{ layout: { sx: { padding: 4 } } }}
       slots={{
         actionBar: props => (
           <Box gridRow={5} gridColumn={'1 / 4'}>

--- a/packages/components/src/DateTimePicker/DateTimePicker.tsx
+++ b/packages/components/src/DateTimePicker/DateTimePicker.tsx
@@ -20,9 +20,9 @@ export const DateTimePicker: typeof MuiDateTimePicker = React.forwardRef(
     <MuiDateTimePicker
       ref={ref}
       /**
-       * The reason for this is here instead of in 
+       * The reason for this is here instead of in
        * packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
-       * is because the layout padding depends on whether the component is wrapping a DateTimePicker or a 
+       * is because the layout padding depends on whether the component is wrapping a DateTimePicker or a
        * DesktopDateTimePicker. The padding is different for each.
        */
       slotProps={{ layout: { sx: { padding: 4 } } }}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -29,6 +29,7 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
         layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
         field: { clearable: true },
         clearIcon: { fontSize: 'medium' },
+        inputAdornment: { sx: { ml: 0 } },
       }}
       closeOnSelect={false}
       views={['minutes', 'seconds']}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -28,6 +28,7 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       slotProps={{
         layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
         field: { clearable: true },
+        clearIcon: { fontSize: 'medium' },
       }}
       closeOnSelect={false}
       views={['minutes', 'seconds']}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -2,8 +2,6 @@ import React from 'react'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 
-import { IconButton } from '../components.js'
-
 /**
  *
  * Demos:
@@ -20,7 +18,6 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       ref={ref}
       slots={{
         actionBar: () => null,
-        clearButton: IconButton,
       }}
       /**
        * The reason for this is here instead of in
@@ -31,7 +28,9 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       slotProps={{
         layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
         field: { clearable: true },
+        textField: { fullWidth: true },
         clearIcon: { fontSize: 'medium' },
+        clearButton: { sx: { opacity: '1 !important' } }, // MUI overrides the opacity to 0 on blur
         inputAdornment: { sx: { ml: 0 } },
       }}
       closeOnSelect={false}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Clear } from '@mui/icons-material'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 
@@ -12,23 +13,29 @@ import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
  *
  * - [DesktopTimePicker API](https://mui.com/x/api/date-pickers/desktop-time-picker/)
  */
-export const DesktopTimePicker: typeof MuiDesktopTimePicker = React.forwardRef(
-  (props, ref) => (
+export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
+  React.forwardRef((props, ref) => (
     <MuiDesktopTimePicker
       ref={ref}
-      slots={{ actionBar: () => null }}
+      slots={{
+        actionBar: () => null,
+      }}
       /**
        * The reason for this is here instead of in
        * packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
        * is because the layout padding depends on whether the component is wrapping a DateTimePicker or a
        * DesktopDateTimePicker. The padding is different for each.
        */
-      slotProps={{ layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } } }}
+      slotProps={{
+        layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
+        field: { clearable: true },
+      }}
       closeOnSelect={false}
+      views={['minutes', 'seconds']}
+      format="mm:ss"
       {...props}
     />
-  ),
-) as typeof MuiDesktopTimePicker
+  )) as typeof MuiDesktopTimePicker
 
 export interface DesktopTimePickerProps<TDate = Date>
   extends MuiDesktopTimePickerProps<TDate> {}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -29,6 +29,7 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
         layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
         field: { clearable: true },
         clearIcon: { fontSize: 'medium' },
+        clearButton: { sx: { opacity: 1 } },
         inputAdornment: { sx: { ml: 0 } },
       }}
       closeOnSelect={false}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Clear } from '@mui/icons-material'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -20,6 +20,9 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       ref={ref}
       slots={{
         actionBar: () => null,
+        /**
+         * NOTE: Overriding this to avoid the opacity: 0 added by MUI to the clear button.
+         */
         clearButton: ({ children, onClick }: IconButtonProps) => (
           <IconButton onClick={onClick}>{children}</IconButton>
         ),

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 
+import { IconButton } from '../components.js'
+
 /**
  *
  * Demos:
@@ -18,6 +20,7 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       ref={ref}
       slots={{
         actionBar: () => null,
+        clearButton: IconButton,
       }}
       /**
        * The reason for this is here instead of in
@@ -29,7 +32,6 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
         layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } },
         field: { clearable: true },
         clearIcon: { fontSize: 'medium' },
-        clearButton: { sx: { opacity: 1 } },
         inputAdornment: { sx: { ml: 0 } },
       }}
       closeOnSelect={false}

--- a/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
+++ b/packages/components/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import type { IconButtonProps } from '@mui/material'
+import { IconButton } from '@mui/material'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 
@@ -18,6 +20,9 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
       ref={ref}
       slots={{
         actionBar: () => null,
+        clearButton: ({ children, onClick }: IconButtonProps) => (
+          <IconButton onClick={onClick}>{children}</IconButton>
+        ),
       }}
       /**
        * The reason for this is here instead of in
@@ -30,7 +35,6 @@ export const DesktopTimeDurationPicker: typeof MuiDesktopTimePicker =
         field: { clearable: true },
         textField: { fullWidth: true },
         clearIcon: { fontSize: 'medium' },
-        clearButton: { sx: { opacity: '1 !important' } }, // MUI overrides the opacity to 0 on blur
         inputAdornment: { sx: { ml: 0 } },
       }}
       closeOnSelect={false}

--- a/packages/components/src/DesktopTimePicker/DesktopTimePicker.tsx
+++ b/packages/components/src/DesktopTimePicker/DesktopTimePicker.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import type { DesktopTimePickerProps as MuiDesktopTimePickerProps } from '@mui/x-date-pickers'
 import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
 
@@ -11,8 +12,23 @@ import { DesktopTimePicker as MuiDesktopTimePicker } from '@mui/x-date-pickers'
  *
  * - [DesktopTimePicker API](https://mui.com/x/api/date-pickers/desktop-time-picker/)
  */
-export const DesktopTimePicker: typeof MuiDesktopTimePicker =
-  MuiDesktopTimePicker
+export const DesktopTimePicker: typeof MuiDesktopTimePicker = React.forwardRef(
+  (props, ref) => (
+    <MuiDesktopTimePicker
+      ref={ref}
+      slots={{ actionBar: () => null }}
+      /**
+       * The reason for this is here instead of in
+       * packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
+       * is because the layout padding depends on whether the component is wrapping a DateTimePicker or a
+       * DesktopDateTimePicker. The padding is different for each.
+       */
+      slotProps={{ layout: { sx: { paddingX: 2, pt: 4, paddingBottom: 6 } } }}
+      {...props}
+      closeOnSelect={false}
+    />
+  ),
+) as typeof MuiDesktopTimePicker
 
 export interface DesktopTimePickerProps<TDate = Date>
   extends MuiDesktopTimePickerProps<TDate> {}

--- a/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
+++ b/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
@@ -12,7 +12,7 @@ export default {
 
 const Template = story<DesktopTimePickerProps<Date>>(
   (args: Partial<DesktopTimePickerProps<Date>>) => {
-    const [value, setValue] = React.useState()
+    const [value, setValue] = React.useState<Date | null>(null)
 
     return (
       <Box>

--- a/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
+++ b/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
@@ -15,7 +15,7 @@ const Template = story<DesktopTimePickerProps<Date>>(
     const [value, setValue] = React.useState<Date | null>(null)
 
     return (
-      <Box>
+      <Box display={'flex'} width={'30%'}>
         <DesktopTimeDurationPicker
           label="For desktop"
           value={value}

--- a/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
+++ b/packages/storybook/src/DesktopTimeDurationPicker/DesktopTimeDurationPicker.stories.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import { Box, type DesktopTimePickerProps } from '@monorail/components'
+import { DesktopTimeDurationPicker } from '@monorail/components/DesktopTimeDurationPicker/DesktopTimeDurationPicker'
+
+import { story } from '../helpers/storybook.js'
+
+export default {
+  title: 'Inputs/Date and Time/Time/DesktopTimeDurationPicker',
+  component: DesktopTimeDurationPicker,
+}
+
+const Template = story<DesktopTimePickerProps<Date>>(
+  (args: Partial<DesktopTimePickerProps<Date>>) => {
+    const [value, setValue] = React.useState()
+
+    return (
+      <Box>
+        <DesktopTimeDurationPicker
+          label="For desktop"
+          value={value}
+          onChange={newValue => {
+            setValue(newValue)
+          }}
+          {...args}
+        />
+      </Box>
+    )
+  },
+)
+
+/**
+ * `DesktopTimePicker` is a lower-level component which renders a time picker suitable for desktop browsers. This should not likely be used directly.
+ */
+export const Default = story(Template)

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
+++ b/packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
@@ -1,6 +1,7 @@
 import { type Components, dividerClasses, type Theme } from '@mui/material'
 import {
   dateCalendarClasses,
+  multiSectionDigitalClockClasses,
   multiSectionDigitalClockSectionClasses,
   pickersCalendarHeaderClasses,
   pickersDayClasses,
@@ -12,9 +13,6 @@ export const MonorailPickersLayoutOverrides: Components<Theme>['MuiPickersLayout
     defaultProps: {},
     styleOverrides: {
       root: ({ theme }) => ({
-        '&': {
-          padding: theme.spacing(4),
-        },
         [`& .${pickersLayoutClasses.actionBar}`]: {
           padding: 0,
           height: 'auto',
@@ -23,7 +21,10 @@ export const MonorailPickersLayoutOverrides: Components<Theme>['MuiPickersLayout
           display: 'none',
         },
 
-        /** Time buttons */
+        /** Time section */
+        [`& .${multiSectionDigitalClockClasses.root}`]: {
+          borderBottom: 'none',
+        },
         [`& .${multiSectionDigitalClockSectionClasses.root}`]: {
           width: 'auto',
           padding: theme.spacing(1),

--- a/packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
+++ b/packages/themes/src/classic/components/PickersLayout/themeOverrides.ts
@@ -33,6 +33,7 @@ export const MonorailPickersLayoutOverrides: Components<Theme>['MuiPickersLayout
             borderRadius: 2,
 
             [`&.Mui-selected`]: {
+              ...theme.typography.subtitle2,
               backgroundColor: theme.palette.default.main,
             },
           },
@@ -84,6 +85,7 @@ export const MonorailPickersLayoutOverrides: Components<Theme>['MuiPickersLayout
             ['&:focus']: {
               backgroundColor: theme.palette.primary.light,
             },
+            ...theme.typography.subtitle2,
           },
 
           /** Disabled days */

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
[Ticket](https://resolvn.atlassian.net/browse/PRTL-4583)

- Removed padding from `themeOverride` object for `MonorailPickersLayoutOverrides` since it affects both DateTimePicker and DesktopTimePicker and it's different for each.
- Added paddings to DateTimePicker and DesktopTimePicker
- Force border bottom to be hidden for timer container


<img width="313" alt="image" src="https://github.com/user-attachments/assets/511dbb00-3d35-45af-8f66-6d7fb0c30aad" />

<img width="385" alt="image" src="https://github.com/user-attachments/assets/b098a0c8-39d6-4a16-a1fc-5100e4d60529" />

