### PR TITLE
[NG-2028] fix: temporary FlexDrawer styles

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/FlexDrawer/FlexDrawer.tsx
+++ b/packages/components/src/FlexDrawer/FlexDrawer.tsx
@@ -110,7 +110,8 @@ const FlexDrawerTemporaryContainer = styled('div', {
   slot: 'TemporaryContainer',
   overridesResolver: (_, styles) => [styles.temporaryContainer],
 })({
-  width: 'min-content',
+  position: 'inherit',
+  width: '100%',
   height: '100%',
   [`& .${flexDrawerClasses.paper}`]: {
     boxSizing: 'border-box',
@@ -147,6 +148,7 @@ const FlexDrawerPaper = styled(Paper, {
   flex: '1 0 auto',
   zIndex: theme.zIndex.drawer,
   ...(ownerState.variant === 'temporary' && {
+    height: 'inherit',
     transition: theme.transitions.create(
       [
         `margin-${oppositeAnchorPosition[ownerState.anchor]}`,
@@ -349,6 +351,7 @@ export const FlexDrawer = React.forwardRef((props, ref) => {
         case 'bottom': {
           return {
             height: `${size}px`,
+            [anchorInvariant]: 0,
             ...(variant === 'persistent' &&
               !open && {
                 [anchorInvariant]: `-${size}px`,
@@ -437,7 +440,6 @@ export const FlexDrawer = React.forwardRef((props, ref) => {
       square
       {...paperProps}
       className={clsx(classes.paper, paperProps?.className)}
-      style={getDrawerStyle(drawerSize, isDragging)}
       ownerState={ownerState}
     >
       {children}
@@ -477,7 +479,10 @@ export const FlexDrawer = React.forwardRef((props, ref) => {
         in={open}
         timeout={transitionDuration}
       >
-        <FlexDrawerTemporaryContainer className={classes.temporaryContainer}>
+        <FlexDrawerTemporaryContainer
+          className={classes.temporaryContainer}
+          style={getDrawerStyle(drawerSize, isDragging)}
+        >
           {props.resizable === true && resizeHandle}
           {temporaryDrawerPaper}
         </FlexDrawerTemporaryContainer>

--- a/packages/components/src/ResizeHandle/ResizeHandle.tsx
+++ b/packages/components/src/ResizeHandle/ResizeHandle.tsx
@@ -35,6 +35,7 @@ export const ResizeHandleRoot = styled('div', {
     backgroundColor: 'transparent',
     position: 'relative',
     zIndex: theme.zIndex.drawer + 1,
+    userSelect: 'none',
     '&:hover': {
       [`& > .${resizeHandleClasses.handle}`]: {
         // border.light isn't the most semantic, but it translates well between light and dark mode

--- a/packages/storybook/src/Drawer/Drawer.stories.tsx
+++ b/packages/storybook/src/Drawer/Drawer.stories.tsx
@@ -34,7 +34,7 @@ import {
   Toolbar,
   Typography,
 } from '@monorail/components'
-import { Home } from '@monorail/components/icons'
+import { Home, Menu } from '@monorail/components/icons'
 
 import { story } from '../helpers/storybook.js'
 
@@ -255,35 +255,7 @@ export const ResponsiveDrawer = story<DrawerProps>(() => {
       </Box>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <Toolbar />
-        <Typography paragraph>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-          dolor purus non enim praesent elementum facilisis leo vel. Risus at
-          ultrices mi tempus imperdiet. Semper risus in hendrerit gravida rutrum
-          quisque non tellus. Convallis convallis tellus id interdum velit
-          laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed
-          adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-          integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-          eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-          quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-          vivamus at augue. At augue eget arcu dictum varius duis at consectetur
-          lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
-          faucibus et molestie ac.
-        </Typography>
-        <Typography paragraph>
-          Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-          ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-          elementum integer enim neque volutpat ac tincidunt. Ornare suspendisse
-          sed nisi lacus sed viverra tellus. Purus sit amet volutpat consequat
-          mauris. Elementum eu facilisis sed odio morbi. Euismod lacinia at quis
-          risus sed vulputate odio. Morbi tincidunt ornare massa eget egestas
-          purus viverra accumsan in. In hendrerit gravida rutrum quisque non
-          tellus orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-          morbi tristique senectus et. Adipiscing elit duis tristique
-          sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
-          eleifend. Commodo viverra maecenas accumsan lacus vel facilisis. Nulla
-          posuere sollicitudin aliquam ultrices sagittis orci a.
-        </Typography>
+        <MainPanelContent />
       </Box>
     </Box>
   )
@@ -432,35 +404,7 @@ export const PersistentDrawer = story<DrawerProps>(() => {
       </Drawer>
       <PersistentDrawerMain open={open}>
         <PersistentDrawerHeader />
-        <Typography component="p">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-          dolor purus non enim praesent elementum facilisis leo vel. Risus at
-          ultrices mi tempus imperdiet. Semper risus in hendrerit gravida rutrum
-          quisque non tellus. Convallis convallis tellus id interdum velit
-          laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed
-          adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-          integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-          eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-          quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-          vivamus at augue. At augue eget arcu dictum varius duis at consectetur
-          lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
-          faucibus et molestie ac.
-        </Typography>
-        <Typography component="p">
-          Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-          ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-          elementum integer enim neque volutpat ac tincidunt. Ornare suspendisse
-          sed nisi lacus sed viverra tellus. Purus sit amet volutpat consequat
-          mauris. Elementum eu facilisis sed odio morbi. Euismod lacinia at quis
-          risus sed vulputate odio. Morbi tincidunt ornare massa eget egestas
-          purus viverra accumsan in. In hendrerit gravida rutrum quisque non
-          tellus orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-          morbi tristique senectus et. Adipiscing elit duis tristique
-          sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
-          eleifend. Commodo viverra maecenas accumsan lacus vel facilisis. Nulla
-          posuere sollicitudin aliquam ultrices sagittis orci a.
-        </Typography>
+        <MainPanelContent />
       </PersistentDrawerMain>
     </Box>
   )
@@ -513,53 +457,7 @@ export const ResizableDrawerLeft_ = story<FlexDrawerProps>(
                 },
               }}
             >
-              <Toolbar />
-              <Divider />
-              <List>
-                {['Inbox', 'Starred', 'Send email', 'Drafts'].map(
-                  (text, index) => (
-                    <ListItem key={text} disablePadding>
-                      <ListItemButton sx={{ width: '100%' }}>
-                        <ListItemIcon>
-                          {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={text}
-                          sx={{
-                            '& > span': {
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            },
-                          }}
-                        />
-                      </ListItemButton>
-                    </ListItem>
-                  ),
-                )}
-              </List>
-              <Divider />
-              <List>
-                {['All mail', 'Trash', 'Spam'].map((text, index) => (
-                  <ListItem key={text} disablePadding>
-                    <ListItemButton sx={{ width: '100%' }}>
-                      <ListItemIcon>
-                        {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={text}
-                        sx={{
-                          '& > span': {
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          },
-                        }}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                ))}
-              </List>
+              <FlexDrawerContent />
             </FlexDrawer>
 
             <Box
@@ -568,38 +466,7 @@ export const ResizableDrawerLeft_ = story<FlexDrawerProps>(
             >
               <Box sx={{ p: 3, overflowY: 'auto' }}>
                 <Button onClick={() => setOpen(!open)}>Open</Button>
-                <Typography paragraph>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Rhoncus dolor purus non enim praesent elementum facilisis leo
-                  vel. Risus at ultrices mi tempus imperdiet. Semper risus in
-                  hendrerit gravida rutrum quisque non tellus. Convallis
-                  convallis tellus id interdum velit laoreet id donec ultrices.
-                  Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl
-                  suscipit adipiscing bibendum est ultricies integer quis.
-                  Cursus euismod quis viverra nibh cras. Metus vulputate eu
-                  scelerisque felis imperdiet proin fermentum leo. Mauris
-                  commodo quis imperdiet massa tincidunt. Cras tincidunt
-                  lobortis feugiat vivamus at augue. At augue eget arcu dictum
-                  varius duis at consectetur lorem. Velit sed ullamcorper morbi
-                  tincidunt. Lorem donec massa sapien faucibus et molestie ac.
-                </Typography>
-                <Typography paragraph>
-                  Consequat mauris nunc congue nisi vitae suscipit. Fringilla
-                  est ullamcorper eget nulla facilisi etiam dignissim diam.
-                  Pulvinar elementum integer enim neque volutpat ac tincidunt.
-                  Ornare suspendisse sed nisi lacus sed viverra tellus. Purus
-                  sit amet volutpat consequat mauris. Elementum eu facilisis sed
-                  odio morbi. Euismod lacinia at quis risus sed vulputate odio.
-                  Morbi tincidunt ornare massa eget egestas purus viverra
-                  accumsan in. In hendrerit gravida rutrum quisque non tellus
-                  orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-                  morbi tristique senectus et. Adipiscing elit duis tristique
-                  sollicitudin nibh sit. Ornare aenean euismod elementum nisi
-                  quis eleifend. Commodo viverra maecenas accumsan lacus vel
-                  facilisis. Nulla posuere sollicitudin aliquam ultrices
-                  sagittis orci a.
-                </Typography>
+                <MainPanelContent />
               </Box>
             </Box>
           </Box>
@@ -634,38 +501,7 @@ export const ResizableDrawerRight_ = story<FlexDrawerProps>(
               sx={{ flexGrow: 1, bgcolor: 'background.default' }}
             >
               <Box sx={{ p: 3, overflowY: 'auto' }}>
-                <Typography paragraph>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Rhoncus dolor purus non enim praesent elementum facilisis leo
-                  vel. Risus at ultrices mi tempus imperdiet. Semper risus in
-                  hendrerit gravida rutrum quisque non tellus. Convallis
-                  convallis tellus id interdum velit laoreet id donec ultrices.
-                  Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl
-                  suscipit adipiscing bibendum est ultricies integer quis.
-                  Cursus euismod quis viverra nibh cras. Metus vulputate eu
-                  scelerisque felis imperdiet proin fermentum leo. Mauris
-                  commodo quis imperdiet massa tincidunt. Cras tincidunt
-                  lobortis feugiat vivamus at augue. At augue eget arcu dictum
-                  varius duis at consectetur lorem. Velit sed ullamcorper morbi
-                  tincidunt. Lorem donec massa sapien faucibus et molestie ac.
-                </Typography>
-                <Typography paragraph>
-                  Consequat mauris nunc congue nisi vitae suscipit. Fringilla
-                  est ullamcorper eget nulla facilisi etiam dignissim diam.
-                  Pulvinar elementum integer enim neque volutpat ac tincidunt.
-                  Ornare suspendisse sed nisi lacus sed viverra tellus. Purus
-                  sit amet volutpat consequat mauris. Elementum eu facilisis sed
-                  odio morbi. Euismod lacinia at quis risus sed vulputate odio.
-                  Morbi tincidunt ornare massa eget egestas purus viverra
-                  accumsan in. In hendrerit gravida rutrum quisque non tellus
-                  orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-                  morbi tristique senectus et. Adipiscing elit duis tristique
-                  sollicitudin nibh sit. Ornare aenean euismod elementum nisi
-                  quis eleifend. Commodo viverra maecenas accumsan lacus vel
-                  facilisis. Nulla posuere sollicitudin aliquam ultrices
-                  sagittis orci a.
-                </Typography>
+                <MainPanelContent />
               </Box>
             </Box>
           </Box>
@@ -681,53 +517,7 @@ export const ResizableDrawerRight_ = story<FlexDrawerProps>(
               },
             }}
           >
-            <Toolbar />
-            <Divider />
-            <List>
-              {['Inbox', 'Starred', 'Send email', 'Drafts'].map(
-                (text, index) => (
-                  <ListItem key={text} disablePadding>
-                    <ListItemButton sx={{ width: '100%' }}>
-                      <ListItemIcon>
-                        {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={text}
-                        sx={{
-                          '& > span': {
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          },
-                        }}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                ),
-              )}
-            </List>
-            <Divider />
-            <List>
-              {['All mail', 'Trash', 'Spam'].map((text, index) => (
-                <ListItem key={text} disablePadding>
-                  <ListItemButton sx={{ width: '100%' }}>
-                    <ListItemIcon>
-                      {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                    </ListItemIcon>
-                    <ListItemText
-                      primary={text}
-                      sx={{
-                        '& > span': {
-                          whiteSpace: 'nowrap',
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                        },
-                      }}
-                    />
-                  </ListItemButton>
-                </ListItem>
-              ))}
-            </List>
+            <FlexDrawerContent />
           </FlexDrawer>
 
           <Stack
@@ -781,36 +571,7 @@ export const ResizableDrawerTop_ = story<FlexDrawerProps>(
           </Box>
         </FlexDrawer>
         <Box sx={{ p: 3, overflowY: 'auto' }}>
-          <Typography paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-            dolor purus non enim praesent elementum facilisis leo vel. Risus at
-            ultrices mi tempus imperdiet. Semper risus in hendrerit gravida
-            rutrum quisque non tellus. Convallis convallis tellus id interdum
-            velit laoreet id donec ultrices. Odio morbi quis commodo odio aenean
-            sed adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-            integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-            eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-            quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-            vivamus at augue. At augue eget arcu dictum varius duis at
-            consectetur lorem. Velit sed ullamcorper morbi tincidunt. Lorem
-            donec massa sapien faucibus et molestie ac.
-          </Typography>
-          <Typography paragraph>
-            Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-            ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-            elementum integer enim neque volutpat ac tincidunt. Ornare
-            suspendisse sed nisi lacus sed viverra tellus. Purus sit amet
-            volutpat consequat mauris. Elementum eu facilisis sed odio morbi.
-            Euismod lacinia at quis risus sed vulputate odio. Morbi tincidunt
-            ornare massa eget egestas purus viverra accumsan in. In hendrerit
-            gravida rutrum quisque non tellus orci ac. Pellentesque nec nam
-            aliquam sem et tortor. Habitant morbi tristique senectus et.
-            Adipiscing elit duis tristique sollicitudin nibh sit. Ornare aenean
-            euismod elementum nisi quis eleifend. Commodo viverra maecenas
-            accumsan lacus vel facilisis. Nulla posuere sollicitudin aliquam
-            ultrices sagittis orci a.
-          </Typography>
+          <MainPanelContent />
         </Box>
       </Box>
     )
@@ -839,36 +600,7 @@ export const ResizableDrawerBottom_ = story<FlexDrawerProps>(
           </Toolbar>
         </AppBar>
         <Box sx={{ p: 3, flexGrow: 1, overflowY: 'auto' }}>
-          <Typography paragraph>
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-            eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-            dolor purus non enim praesent elementum facilisis leo vel. Risus at
-            ultrices mi tempus imperdiet. Semper risus in hendrerit gravida
-            rutrum quisque non tellus. Convallis convallis tellus id interdum
-            velit laoreet id donec ultrices. Odio morbi quis commodo odio aenean
-            sed adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-            integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-            eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-            quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-            vivamus at augue. At augue eget arcu dictum varius duis at
-            consectetur lorem. Velit sed ullamcorper morbi tincidunt. Lorem
-            donec massa sapien faucibus et molestie ac.
-          </Typography>
-          <Typography paragraph>
-            Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-            ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-            elementum integer enim neque volutpat ac tincidunt. Ornare
-            suspendisse sed nisi lacus sed viverra tellus. Purus sit amet
-            volutpat consequat mauris. Elementum eu facilisis sed odio morbi.
-            Euismod lacinia at quis risus sed vulputate odio. Morbi tincidunt
-            ornare massa eget egestas purus viverra accumsan in. In hendrerit
-            gravida rutrum quisque non tellus orci ac. Pellentesque nec nam
-            aliquam sem et tortor. Habitant morbi tristique senectus et.
-            Adipiscing elit duis tristique sollicitudin nibh sit. Ornare aenean
-            euismod elementum nisi quis eleifend. Commodo viverra maecenas
-            accumsan lacus vel facilisis. Nulla posuere sollicitudin aliquam
-            ultrices sagittis orci a.
-          </Typography>
+          <MainPanelContent />
         </Box>
         <FlexDrawer
           resizable
@@ -906,6 +638,78 @@ export const ResizableDrawerBottom_ = story<FlexDrawerProps>(
   {
     parameters: {
       layout: 'fullscreen',
+    },
+  },
+)
+
+export const ResizableTemporaryDrawer = story<FlexDrawerProps>(
+  args => {
+    const [open, setOpen] = React.useState(true)
+    return (
+      <Stack direction="column" width="100vw" height="100vh">
+        <Stack direction="row" height={1}>
+          <Box overflow="hidden" height="100%" sx={{ display: 'flex' }}>
+            <CssBaseline />
+            <GlobalStyles
+              styles={{
+                'html, body, #root': {
+                  height: '100%',
+                },
+              }}
+            />
+
+            <Box
+              component="main"
+              sx={{ flexGrow: 1, bgcolor: 'background.default' }}
+            >
+              <Box sx={{ p: 3, overflowY: 'auto' }}>
+                <MainPanelContent />
+              </Box>
+            </Box>
+          </Box>
+
+          <FlexDrawer
+            resizable={args.resizable}
+            minSize={60}
+            onClose={() => setOpen(false)}
+            maxSize={400}
+            variant="temporary"
+            open={open}
+            anchor={args.anchor}
+            slotProps={{
+              paper: {
+                elevation: 16,
+              },
+            }}
+          >
+            <FlexDrawerContent />
+          </FlexDrawer>
+
+          <Stack
+            minWidth={64}
+            flexGrow={1}
+            alignItems="center"
+            bgcolor="common.black"
+            py={4}
+          >
+            <IconButton aria-label="Home">
+              <Menu
+                sx={theme => ({ fill: theme.palette.common.white })}
+                onClick={() => setOpen(!open)}
+              />
+            </IconButton>
+          </Stack>
+        </Stack>
+      </Stack>
+    )
+  },
+  {
+    parameters: {
+      layout: 'fullscreen',
+    },
+    args: {
+      resizable: true,
+      anchor: 'left',
     },
   },
 )
@@ -1059,35 +863,7 @@ export const MiniDrawer = story<DrawerProps>(() => {
       </MiniVariantDrawer>
       <Box component="main" sx={{ flexGrow: 1, p: 3 }}>
         <DrawerHeader />
-        <Typography paragraph>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-          eiusmod tempor incididunt ut labore et dolore magna aliqua. Rhoncus
-          dolor purus non enim praesent elementum facilisis leo vel. Risus at
-          ultrices mi tempus imperdiet. Semper risus in hendrerit gravida rutrum
-          quisque non tellus. Convallis convallis tellus id interdum velit
-          laoreet id donec ultrices. Odio morbi quis commodo odio aenean sed
-          adipiscing. Amet nisl suscipit adipiscing bibendum est ultricies
-          integer quis. Cursus euismod quis viverra nibh cras. Metus vulputate
-          eu scelerisque felis imperdiet proin fermentum leo. Mauris commodo
-          quis imperdiet massa tincidunt. Cras tincidunt lobortis feugiat
-          vivamus at augue. At augue eget arcu dictum varius duis at consectetur
-          lorem. Velit sed ullamcorper morbi tincidunt. Lorem donec massa sapien
-          faucibus et molestie ac.
-        </Typography>
-        <Typography paragraph>
-          Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
-          ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar
-          elementum integer enim neque volutpat ac tincidunt. Ornare suspendisse
-          sed nisi lacus sed viverra tellus. Purus sit amet volutpat consequat
-          mauris. Elementum eu facilisis sed odio morbi. Euismod lacinia at quis
-          risus sed vulputate odio. Morbi tincidunt ornare massa eget egestas
-          purus viverra accumsan in. In hendrerit gravida rutrum quisque non
-          tellus orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-          morbi tristique senectus et. Adipiscing elit duis tristique
-          sollicitudin nibh sit. Ornare aenean euismod elementum nisi quis
-          eleifend. Commodo viverra maecenas accumsan lacus vel facilisis. Nulla
-          posuere sollicitudin aliquam ultrices sagittis orci a.
-        </Typography>
+        <MainPanelContent />
       </Box>
     </Box>
   )
@@ -1132,53 +908,7 @@ export const FlexDrawerLeft: StoryObj<typeof FlexDrawer> = {
                 },
               }}
             >
-              <Toolbar />
-              <Divider />
-              <List>
-                {['Inbox', 'Starred', 'Send email', 'Drafts'].map(
-                  (text, index) => (
-                    <ListItem key={text} disablePadding>
-                      <ListItemButton sx={{ width: '100%' }}>
-                        <ListItemIcon>
-                          {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                        </ListItemIcon>
-                        <ListItemText
-                          primary={text}
-                          sx={{
-                            '& > span': {
-                              whiteSpace: 'nowrap',
-                              overflow: 'hidden',
-                              textOverflow: 'ellipsis',
-                            },
-                          }}
-                        />
-                      </ListItemButton>
-                    </ListItem>
-                  ),
-                )}
-              </List>
-              <Divider />
-              <List>
-                {['All mail', 'Trash', 'Spam'].map((text, index) => (
-                  <ListItem key={text} disablePadding>
-                    <ListItemButton sx={{ width: '100%' }}>
-                      <ListItemIcon>
-                        {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
-                      </ListItemIcon>
-                      <ListItemText
-                        primary={text}
-                        sx={{
-                          '& > span': {
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                          },
-                        }}
-                      />
-                    </ListItemButton>
-                  </ListItem>
-                ))}
-              </List>
+              <FlexDrawerContent />
             </FlexDrawer>
 
             <Box
@@ -1187,38 +917,7 @@ export const FlexDrawerLeft: StoryObj<typeof FlexDrawer> = {
             >
               <Box sx={{ p: 3, overflowY: 'auto' }}>
                 <Button onClick={() => setOpen(!open)}>Open</Button>
-                <Typography paragraph>
-                  Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed
-                  do eiusmod tempor incididunt ut labore et dolore magna aliqua.
-                  Rhoncus dolor purus non enim praesent elementum facilisis leo
-                  vel. Risus at ultrices mi tempus imperdiet. Semper risus in
-                  hendrerit gravida rutrum quisque non tellus. Convallis
-                  convallis tellus id interdum velit laoreet id donec ultrices.
-                  Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl
-                  suscipit adipiscing bibendum est ultricies integer quis.
-                  Cursus euismod quis viverra nibh cras. Metus vulputate eu
-                  scelerisque felis imperdiet proin fermentum leo. Mauris
-                  commodo quis imperdiet massa tincidunt. Cras tincidunt
-                  lobortis feugiat vivamus at augue. At augue eget arcu dictum
-                  varius duis at consectetur lorem. Velit sed ullamcorper morbi
-                  tincidunt. Lorem donec massa sapien faucibus et molestie ac.
-                </Typography>
-                <Typography paragraph>
-                  Consequat mauris nunc congue nisi vitae suscipit. Fringilla
-                  est ullamcorper eget nulla facilisi etiam dignissim diam.
-                  Pulvinar elementum integer enim neque volutpat ac tincidunt.
-                  Ornare suspendisse sed nisi lacus sed viverra tellus. Purus
-                  sit amet volutpat consequat mauris. Elementum eu facilisis sed
-                  odio morbi. Euismod lacinia at quis risus sed vulputate odio.
-                  Morbi tincidunt ornare massa eget egestas purus viverra
-                  accumsan in. In hendrerit gravida rutrum quisque non tellus
-                  orci ac. Pellentesque nec nam aliquam sem et tortor. Habitant
-                  morbi tristique senectus et. Adipiscing elit duis tristique
-                  sollicitudin nibh sit. Ornare aenean euismod elementum nisi
-                  quis eleifend. Commodo viverra maecenas accumsan lacus vel
-                  facilisis. Nulla posuere sollicitudin aliquam ultrices
-                  sagittis orci a.
-                </Typography>
+                <MainPanelContent />
               </Box>
             </Box>
           </Box>
@@ -1229,4 +928,91 @@ export const FlexDrawerLeft: StoryObj<typeof FlexDrawer> = {
   parameters: {
     layout: 'fullscreen',
   },
+}
+
+const MainPanelContent = () => {
+  return (
+    <>
+      <Typography>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Rhoncus dolor purus
+        non enim praesent elementum facilisis leo vel. Risus at ultrices mi
+        tempus imperdiet. Semper risus in hendrerit gravida rutrum quisque non
+        tellus. Convallis convallis tellus id interdum velit laoreet id donec
+        ultrices. Odio morbi quis commodo odio aenean sed adipiscing. Amet nisl
+        suscipit adipiscing bibendum est ultricies integer quis. Cursus euismod
+        quis viverra nibh cras. Metus vulputate eu scelerisque felis imperdiet
+        proin fermentum leo. Mauris commodo quis imperdiet massa tincidunt. Cras
+        tincidunt lobortis feugiat vivamus at augue. At augue eget arcu dictum
+        varius duis at consectetur lorem. Velit sed ullamcorper morbi tincidunt.
+        Lorem donec massa sapien faucibus et molestie ac.
+      </Typography>
+      <Typography>
+        Consequat mauris nunc congue nisi vitae suscipit. Fringilla est
+        ullamcorper eget nulla facilisi etiam dignissim diam. Pulvinar elementum
+        integer enim neque volutpat ac tincidunt. Ornare suspendisse sed nisi
+        lacus sed viverra tellus. Purus sit amet volutpat consequat mauris.
+        Elementum eu facilisis sed odio morbi. Euismod lacinia at quis risus sed
+        vulputate odio. Morbi tincidunt ornare massa eget egestas purus viverra
+        accumsan in. In hendrerit gravida rutrum quisque non tellus orci ac.
+        Pellentesque nec nam aliquam sem et tortor. Habitant morbi tristique
+        senectus et. Adipiscing elit duis tristique sollicitudin nibh sit.
+        Ornare aenean euismod elementum nisi quis eleifend. Commodo viverra
+        maecenas accumsan lacus vel facilisis. Nulla posuere sollicitudin
+        aliquam ultrices sagittis orci a.
+      </Typography>
+    </>
+  )
+}
+
+const FlexDrawerContent = () => {
+  return (
+    <>
+      <Toolbar />
+      <Divider />
+      <List>
+        {['Inbox', 'Starred', 'Send email', 'Drafts'].map((text, index) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton sx={{ width: '100%' }}>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText
+                primary={text}
+                sx={{
+                  '& > span': {
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  },
+                }}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+      <Divider />
+      <List>
+        {['All mail', 'Trash', 'Spam'].map((text, index) => (
+          <ListItem key={text} disablePadding>
+            <ListItemButton sx={{ width: '100%' }}>
+              <ListItemIcon>
+                {index % 2 === 0 ? <InboxIcon /> : <MailIcon />}
+              </ListItemIcon>
+              <ListItemText
+                primary={text}
+                sx={{
+                  '& > span': {
+                    whiteSpace: 'nowrap',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                  },
+                }}
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </>
+  )
 }

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.2.3",
+  "version": "3.2.4",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
https://resolvn.atlassian.net/browse/NG-2028

## Summary

This PR fixes the `FlexDrawer` styles when the following props are used:

- `variant="temporary'`
- `resizable={true}`
- `anchor="right | top | bottom"`

## Screenshots

### `anchor="right"`

Before
![image](https://github.com/user-attachments/assets/02c662b7-58f9-44d6-bb59-6ef33ed22658)

After
<img width="908" alt="image" src="https://github.com/user-attachments/assets/e496d110-0867-4caa-877a-6bc34dab25e2" />

### `anchor="top"`

Before
![image](https://github.com/user-attachments/assets/5dcc1441-dde9-4ec1-b127-6f076830bbed)

After
<img width="906" alt="image" src="https://github.com/user-attachments/assets/adf386bc-e166-450f-910d-f8326e44c8c5" />

### `anchor="bottom"`

Before
![image](https://github.com/user-attachments/assets/ab8b3753-f911-49da-82a3-50a2484a86c8)

After
<img width="911" alt="image" src="https://github.com/user-attachments/assets/f3526b4f-e10c-4dd9-9403-00af8486aeaa" />



