### PR TITLE
[NO-TICKET] fix(DialogHeader): wrap text when title is too long

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/DialogHeader/DialogHeader.tsx
+++ b/packages/components/src/DialogHeader/DialogHeader.tsx
@@ -8,7 +8,6 @@ import clsx from 'clsx'
 
 import { composeClasses, sx } from '@monorail/utils'
 
-import { Box } from '../Box.js'
 import { DialogEventContext } from '../Dialog/dialogEventContext.js'
 import { IconButton } from '../IconButton.js'
 import { Typography } from '../Typography.js'
@@ -41,12 +40,18 @@ const DialogHeaderRoot = styled('div', {
   overridesResolver,
 })<DialogHeaderRootProps>(
   sx(theme => ({
-    padding: theme.spacing(4, 6),
-    height: theme.spacing(14),
+    padding: theme.spacing(2, 6),
+    minHeight: theme.spacing(14),
     flex: '0 0 auto',
     display: 'flex',
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-start',
+    gap: theme.spacing(4),
+
+    [` .${dialogHeaderClasses.title}`]: {
+      pt: 2,
+      flex: 1,
+    },
   })),
 )
 
@@ -56,7 +61,7 @@ const DialogIconContainer = styled('div', {
 })(
   sx(theme => ({
     display: 'flex',
-    marginRight: theme.spacing(4),
+    py: theme.spacing(2),
   })),
 )
 
@@ -90,7 +95,6 @@ export const DialogHeader = React.forwardRef(function DialogHeader(
         component="span"
         variant="h3"
         className={classes.title}
-        flex="1 0 auto"
         {...slotProps.typography}
       >
         {title}
@@ -126,7 +130,6 @@ export const DialogHeader = React.forwardRef(function DialogHeader(
         </DialogIconContainer>
       )}
       {title}
-      <Box sx={{ width: '100%' }} />
       {closeButton}
     </DialogHeaderRoot>
   )

--- a/packages/components/src/DialogHeader/dialogHeaderProps.ts
+++ b/packages/components/src/DialogHeader/dialogHeaderProps.ts
@@ -17,7 +17,7 @@ export interface DialogHeaderProps
   /**
    * The title displayed in the header
    */
-  title: React.ReactChild
+  title: React.ReactNode
   /**
    * The icon to the left of the title
    * @default undefined

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
This PR fixes `DialogHeader`'s text overflow bug.

## Before

![image](https://github.com/user-attachments/assets/19904dac-8e63-4d10-91c6-9f90b7a679dc)

## After

![image](https://github.com/user-attachments/assets/0933a97a-b027-48c0-89a3-11d1ca0e7545)

With `slotProps.typography.lineClamp`

![image](https://github.com/user-attachments/assets/95210907-a3b7-44f3-8ce0-5f62ec042bfb)

![image](https://github.com/user-attachments/assets/104a864c-3c87-4462-9012-aff26e8b6f50)

