### PR TITLE
[PRTL-4871] Adapt UploadFile component to accept multiple files

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/components/src/FileUpload/fileUploadProps.ts
+++ b/packages/components/src/FileUpload/fileUploadProps.ts
@@ -26,7 +26,7 @@ export interface FileUploadProps
   /**
    * The file to upload.
    */
-  file: File | ReadonlyArray<File> | null
+  files: ReadonlyArray<File> | null
   /**
    * Progress of the upload.
    */
@@ -60,7 +60,7 @@ export interface FileUploadProps
   /**
    * Callback fired when the value is changed.
    */
-  onChange: (file: File | ReadonlyArray<File> | null) => void
+  onChange: (file: ReadonlyArray<File> | null) => void
   /**
    * If `true`, the `dropTarget` element will only be visible while a file is being dragged into the viewport.
    * @default false

--- a/packages/components/src/FileUpload/fileUploadProps.ts
+++ b/packages/components/src/FileUpload/fileUploadProps.ts
@@ -60,7 +60,7 @@ export interface FileUploadProps
   /**
    * Callback fired when the value is changed.
    */
-  onChange: (file: ReadonlyArray<File> | null) => void
+  onChange: (files: ReadonlyArray<File> | null) => void
   /**
    * If `true`, the `dropTarget` element will only be visible while a file is being dragged into the viewport.
    * @default false

--- a/packages/components/src/FileUpload/fileUploadProps.ts
+++ b/packages/components/src/FileUpload/fileUploadProps.ts
@@ -26,7 +26,7 @@ export interface FileUploadProps
   /**
    * The file to upload.
    */
-  file: File | null
+  file: File | ReadonlyArray<File> | null
   /**
    * Progress of the upload.
    */
@@ -60,7 +60,7 @@ export interface FileUploadProps
   /**
    * Callback fired when the value is changed.
    */
-  onChange: (file: File | null) => void
+  onChange: (file: File | ReadonlyArray<File> | null) => void
   /**
    * If `true`, the `dropTarget` element will only be visible while a file is being dragged into the viewport.
    * @default false
@@ -105,4 +105,9 @@ export interface FileUploadProps
     label?: Partial<InputLabelProps & DataAttributes>
   }
   sx?: SxProps<Theme>
+  /**
+   * Allow multiple files to be uploaded.
+   * @default false
+   */
+  multiple?: boolean
 }

--- a/packages/storybook/src/FileUpload/FileUpload.stories.tsx
+++ b/packages/storybook/src/FileUpload/FileUpload.stories.tsx
@@ -12,9 +12,7 @@ export default { title: 'Inputs/FileUpload', component: FileUpload }
 
 const Template = story<FileUploadProps>(
   args => {
-    const [file, setFile] = React.useState<File | ReadonlyArray<File> | null>(
-      null,
-    )
+    const [file, setFile] = React.useState<ReadonlyArray<File> | null>(null)
     const [progress, setProgress] = React.useState<number | null>(null)
 
     React.useEffect(() => {
@@ -46,7 +44,7 @@ const Template = story<FileUploadProps>(
     return (
       <DndProvider backend={HTML5Backend}>
         <FileUpload
-          file={file}
+          files={file}
           label="File upload"
           onChange={value => setFile(value)}
           uploadProgress={progress}
@@ -64,7 +62,7 @@ export const Status = story<FileUploadProps>(args => (
   <DndProvider backend={HTML5Backend}>
     <Stack gap={4}>
       <FileUpload
-        file={null}
+        files={null}
         helperTextPrimary="My custom text for drop target"
         label={'Default'}
         required
@@ -74,35 +72,35 @@ export const Status = story<FileUploadProps>(args => (
       />
       <FileUpload
         label="In Progress"
-        file={
+        files={[
           {
             lastModified: new Date().getTime(),
             name: 'this_is_a_really_really_long_file_name_that_should_trigger_an_ellipsis_when_its_container_reaches_the_defined_max_width.csv',
             size: 3000,
             type: '',
-          } as unknown as File
-        }
+          } as unknown as File,
+        ]}
         uploadProgress={67}
         onChange={() => void 0}
         {...args}
       />
       <FileUpload
         label="Uploaded"
-        file={
+        files={[
           {
             lastModified: new Date().getTime(),
             name: 'the_file_i_totally_dropped',
             size: 3000,
             type: '',
-          } as unknown as File
-        }
+          } as unknown as File,
+        ]}
         onChange={() => void 0}
         uploadProgress={null}
         {...args}
       />
       <FileUpload
         label={'Error'}
-        file={null}
+        files={null}
         uploadProgress={null}
         onChange={() => void 0}
         error
@@ -110,7 +108,7 @@ export const Status = story<FileUploadProps>(args => (
       />
       <FileUpload
         disabled
-        file={null}
+        files={null}
         label={'Disabled'}
         required
         onChange={() => void 0}
@@ -143,7 +141,7 @@ export const OnlyVisibleWhileDragging = story<FileUploadProps>(args => (
         </Typography>
       </Stack>
       <FileUpload
-        file={null}
+        files={null}
         onChange={() => void 0}
         uploadProgress={null}
         onlyVisibleWhileDragging
@@ -155,17 +153,17 @@ export const OnlyVisibleWhileDragging = story<FileUploadProps>(args => (
 
 export const Multiple = story<FileUploadProps>(
   args => {
-    const [files, setFiles] = React.useState<ReadonlyArray<File> | File | null>(
-      null,
-    )
+    const [files, setFiles] = React.useState<ReadonlyArray<File> | null>(null)
 
     return (
       <DndProvider backend={HTML5Backend}>
         <FileUpload
-          file={files}
+          files={files}
           multiple
           label="File upload"
-          onChange={value => setFiles(value)}
+          onChange={value => {
+            setFiles(value)
+          }}
           uploadProgress={null}
           {...args}
         />

--- a/packages/storybook/src/FileUpload/FileUpload.stories.tsx
+++ b/packages/storybook/src/FileUpload/FileUpload.stories.tsx
@@ -12,11 +12,11 @@ export default { title: 'Inputs/FileUpload', component: FileUpload }
 
 const Template = story<FileUploadProps>(
   args => {
-    const [file, setFile] = React.useState<ReadonlyArray<File> | null>(null)
+    const [files, setFiles] = React.useState<ReadonlyArray<File> | null>(null)
     const [progress, setProgress] = React.useState<number | null>(null)
 
     React.useEffect(() => {
-      if (file === null) {
+      if (files === null) {
         setProgress(null)
         return
       }
@@ -25,7 +25,7 @@ const Template = story<FileUploadProps>(
 
       const timer = setInterval(() => {
         setProgress(prevProgress => {
-          if (prevProgress === null || file === null) {
+          if (prevProgress === null || files === null) {
             return null
           }
           if (prevProgress >= 90) {
@@ -39,14 +39,14 @@ const Template = story<FileUploadProps>(
       return () => {
         clearInterval(timer)
       }
-    }, [file])
+    }, [files])
 
     return (
       <DndProvider backend={HTML5Backend}>
         <FileUpload
-          files={file}
+          files={files}
           label="File upload"
-          onChange={value => setFile(value)}
+          onChange={value => setFiles(value)}
           uploadProgress={progress}
           {...args}
         />

--- a/packages/storybook/src/FileUpload/FileUpload.stories.tsx
+++ b/packages/storybook/src/FileUpload/FileUpload.stories.tsx
@@ -12,7 +12,9 @@ export default { title: 'Inputs/FileUpload', component: FileUpload }
 
 const Template = story<FileUploadProps>(
   args => {
-    const [file, setFile] = React.useState<File | null>(null)
+    const [file, setFile] = React.useState<File | ReadonlyArray<File> | null>(
+      null,
+    )
     const [progress, setProgress] = React.useState<number | null>(null)
 
     React.useEffect(() => {
@@ -150,3 +152,25 @@ export const OnlyVisibleWhileDragging = story<FileUploadProps>(args => (
     </Box>
   </DndProvider>
 ))
+
+export const Multiple = story<FileUploadProps>(
+  args => {
+    const [files, setFiles] = React.useState<ReadonlyArray<File> | File | null>(
+      null,
+    )
+
+    return (
+      <DndProvider backend={HTML5Backend}>
+        <FileUpload
+          file={files}
+          multiple
+          label="File upload"
+          onChange={value => setFiles(value)}
+          uploadProgress={null}
+          {...args}
+        />
+      </DndProvider>
+    )
+  },
+  { args: {} },
+)

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.8",
+  "version": "3.3.0",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {


### PR DESCRIPTION
These are breaking changes as now `UploadFile` returns a `ReadonlyArray<File>`. 

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/17e38c7a-7d25-4e1e-97ce-cf99409cd3f3" />

<img width="1072" alt="image" src="https://github.com/user-attachments/assets/230a6b06-0b5c-4404-8ff8-9c2120920515" />
