### PR TITLE
[NG-2131] Fix PaginationItem colors

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/components",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Monorail 3 Components Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/package.json
+++ b/packages/themes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/themes",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "description": "Monorail 3 Themes Library",
   "license": "Apache-2.0",
   "author": "SimSpace",

--- a/packages/themes/src/meteor/components/PaginationItem/themeOverrides.ts
+++ b/packages/themes/src/meteor/components/PaginationItem/themeOverrides.ts
@@ -31,7 +31,7 @@ export const MonorailPaginationItemOverrides: Components<Theme>['MuiPaginationIt
             fontWeight: theme.typography.fontWeightBold,
             '&:hover': {
               backgroundColor: alpha(
-                theme.palette.primary.main,
+                theme.palette.default.main,
                 theme.palette.action.selectedOpacity +
                   theme.palette.action.hoverOpacity,
               ),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/types",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "license": "Apache-2.0",
   "typesVersions": {
     "*": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@monorail/utils",
-  "version": "3.2.8",
+  "version": "3.2.9",
   "license": "Apache-2.0",
   "exports": {
     "./*": {


### PR DESCRIPTION
Jira: https://resolvn.atlassian.net/browse/NG-2131

This fixes the red hover color on a pagination item

before:
<img width="2135" alt="before" src="https://github.com/user-attachments/assets/80aea98c-4975-415c-858d-551de14f5ac4" />

after:
<img width="2136" alt="after" src="https://github.com/user-attachments/assets/8d3d8a7c-dbd0-4a9e-ad0b-e64fcf2a2589" />
